### PR TITLE
ci(ios): Periphery品質ゲート厳格化 - continue-on-error削除

### DIFF
--- a/.github/workflows/ios-quality-gate.yml
+++ b/.github/workflows/ios-quality-gate.yml
@@ -29,9 +29,7 @@ jobs:
   periphery:
     name: Periphery (Dead Code Detection)
     runs-on: macos-latest
-    # Phase 1: レポートのみ（失敗させない）
-    # Phase 2で continue-on-error を削除して厳格化予定
-    continue-on-error: true
+    # Phase 4完了: 警告0件達成。厳格モード有効（失敗でPRを落とす）
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,7 +42,7 @@ jobs:
 
       # --project と --schemes を指定してビルドしながらスキャン
       # --format checkstyle でCI連携しやすいレポート形式で出力
-      # Note: continue-on-error: true があるため、失敗してもPRは落ちない
+      # Phase 4完了: 厳格モード有効（未使用コードがあればPRを落とす）
       - name: Run Periphery
         run: |
           cd ios-apps/final-hourglass


### PR DESCRIPTION
## Summary
- Periphery Phase 4完了により未使用コード警告0件達成
- `continue-on-error: true` を削除し厳格モード有効化
- 未使用コードが検出された場合、PRが失敗するようになる

## iOS品質状態
| メトリクス | 件数 |
|-----------|------|
| SwiftLint警告 | 0件 |
| Periphery警告 | 0件（240件→22件→0件 / 100%削減） |
| ビルド警告 | 0件 |

## Test plan
- [ ] CI「iOS Quality Gate」ワークフローが通過することを確認
- [ ] SwiftLint、Periphery、Buildジョブがすべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS品質ゲートの検証基準を強化しました。未使用コードを検出した場合、プルリクエストが失敗するようになります。これにより、コード品質チェックがより厳密に実行されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->