### PR TITLE
ci(ios): workflow_dispatch手動トリガー追加

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -2,6 +2,13 @@
 name: iOS Tests
 
 on:
+  workflow_dispatch:
+    inputs:
+      skip_coverage_check:
+        description: 'カバレッジ閾値チェックをスキップ'
+        required: false
+        default: false
+        type: boolean
   pull_request:
     paths:
       - 'ios-apps/**/*.swift'
@@ -93,6 +100,7 @@ jobs:
           echo "_Threshold: 80% for core calculation logic (LifeExpectancyCalculator, HealthScoreCalculator)_" >> $GITHUB_STEP_SUMMARY
 
       - name: Coverage Threshold Check
+        if: ${{ github.event.inputs.skip_coverage_check != 'true' }}
         run: |
           echo "🔍 Checking coverage thresholds for core calculation logic..."
           THRESHOLD=80


### PR DESCRIPTION
## Summary
- iOS Testsワークフローに手動トリガー（workflow_dispatch）を追加
- skip_coverage_check オプション追加（デバッグ用）

## Changes
- `.github/workflows/ios-test.yml`: workflow_dispatch トリガー追加

## 目的
- ワークフローの動作確認を即座に実行可能に
- カバレッジ閾値チェックをスキップしてテストのみ実行するオプション

## Test plan
- [ ] workflow_dispatch で手動実行が可能なことを確認
- [ ] skip_coverage_check オプションが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS testing workflow configuration with optional coverage check controls for development processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->