### PR TITLE
ci(ios): Phase 17 ビルドメトリクス監視

### DIFF
--- a/.github/workflows/ios-build-metrics.yml
+++ b/.github/workflows/ios-build-metrics.yml
@@ -1,0 +1,193 @@
+name: iOS Build Metrics
+
+on:
+  pull_request:
+    paths:
+      - 'ios-apps/**/*.swift'
+      - 'ios-apps/**/Podfile'
+      - 'ios-apps/**/Podfile.lock'
+      - 'ios-apps/**/*.xcodeproj/**'
+      - 'ios-apps/**/*.xcworkspace/**'
+  push:
+    branches: [main]
+    paths:
+      - 'ios-apps/**/*.swift'
+      - 'ios-apps/**/Podfile'
+      - 'ios-apps/**/Podfile.lock'
+      - 'ios-apps/**/*.xcodeproj/**'
+      - 'ios-apps/**/*.xcworkspace/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-metrics:
+    runs-on: macos-15
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ios-apps/final-hourglass
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: ios-apps/final-hourglass/Pods
+          key: pods-${{ hashFiles('ios-apps/final-hourglass/Podfile.lock') }}
+          restore-keys: pods-
+
+      - name: Install CocoaPods dependencies
+        run: pod install --repo-update
+
+      - name: Build archive and capture metrics
+        id: build
+        run: |
+          set -euo pipefail
+
+          ARCHIVE_PATH="${RUNNER_TEMP}/FinalHourglass.xcarchive"
+          BUILD_LOG="${RUNNER_TEMP}/build.log"
+
+          # Record start time
+          START_TIME=$(date +%s)
+
+          # Build archive, tee output to log
+          xcodebuild archive \
+            -workspace FinalHourglass.xcworkspace \
+            -scheme FinalHourglass \
+            -configuration Release \
+            -archivePath "$ARCHIVE_PATH" \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            2>&1 | tee "$BUILD_LOG"
+
+          END_TIME=$(date +%s)
+          ARCHIVE_SECONDS=$((END_TIME - START_TIME))
+
+          # Calculate app bundle size
+          APP_PATH=$(find "$ARCHIVE_PATH/Products/Applications" -name "*.app" -maxdepth 1 | head -1)
+          if [ -n "$APP_PATH" ]; then
+            SIZE_BYTES=$(du -sk "$APP_PATH" | cut -f1)
+            SIZE_KB=$SIZE_BYTES
+            SIZE_MB=$(echo "scale=1; $SIZE_KB / 1024" | bc)
+          else
+            echo "::error::No .app bundle found in archive"
+            exit 1
+          fi
+
+          # Count build warnings
+          WARNING_COUNT=$(grep -c "warning:" "$BUILD_LOG" || true)
+
+          # Export outputs
+          echo "app_size_mb=$SIZE_MB" >> "$GITHUB_OUTPUT"
+          echo "app_size_kb=$SIZE_KB" >> "$GITHUB_OUTPUT"
+          echo "warning_count=$WARNING_COUNT" >> "$GITHUB_OUTPUT"
+          echo "archive_seconds=$ARCHIVE_SECONDS" >> "$GITHUB_OUTPUT"
+
+      - name: Download baseline metrics
+        id: baseline
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: ios-build-metrics-baseline
+          branch: main
+          workflow: ios-build-metrics.yml
+          path: ${{ runner.temp }}/baseline
+          if_no_artifact_found: warn
+
+      - name: Calculate size delta
+        id: delta
+        run: |
+          CURRENT_KB=${{ steps.build.outputs.app_size_kb }}
+          BASELINE_FILE="${RUNNER_TEMP}/baseline/metrics.json"
+
+          if [ -f "$BASELINE_FILE" ]; then
+            BASELINE_KB=$(jq -r '.app_size_kb' "$BASELINE_FILE")
+            DELTA_KB=$((CURRENT_KB - BASELINE_KB))
+            if [ "$BASELINE_KB" -gt 0 ]; then
+              DELTA_PCT=$(echo "scale=1; $DELTA_KB * 100 / $BASELINE_KB" | bc)
+            else
+              DELTA_PCT="N/A"
+            fi
+
+            if [ "$DELTA_KB" -ge 0 ]; then
+              DELTA_DISPLAY="+$(echo "scale=1; $DELTA_KB / 1024" | bc) MB (+${DELTA_PCT}%)"
+            else
+              DELTA_DISPLAY="$(echo "scale=1; $DELTA_KB / 1024" | bc) MB (${DELTA_PCT}%)"
+            fi
+            echo "delta_display=$DELTA_DISPLAY" >> "$GITHUB_OUTPUT"
+            echo "has_baseline=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "delta_display=—" >> "$GITHUB_OUTPUT"
+            echo "has_baseline=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate metrics report
+        run: |
+          SIZE_MB="${{ steps.build.outputs.app_size_mb }}"
+          WARNINGS="${{ steps.build.outputs.warning_count }}"
+          ARCHIVE_SEC="${{ steps.build.outputs.archive_seconds }}"
+          DELTA="${{ steps.delta.outputs.delta_display }}"
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## 📊 iOS Build Metrics
+
+          | Metric | Value | Change |
+          |--------|-------|--------|
+          | App Bundle Size | ${SIZE_MB} MB | ${DELTA} |
+          | Build Warnings | ${WARNINGS} | — |
+          | Archive Time | ${ARCHIVE_SEC}s | — |
+
+          EOF
+
+          # Threshold checks
+          SIZE_KB=${{ steps.build.outputs.app_size_kb }}
+          LIMIT_WARNING=$((100 * 1024))
+          LIMIT_FAIL=$((150 * 1024))
+
+          if [ "$SIZE_KB" -gt "$LIMIT_FAIL" ]; then
+            echo "::error::App size ${SIZE_MB} MB exceeds App Store limit (150 MB)"
+            echo "❌ **App size exceeds 150 MB App Store limit!**" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          elif [ "$SIZE_KB" -gt "$LIMIT_WARNING" ]; then
+            echo "::warning::App size ${SIZE_MB} MB approaching App Store limit (150 MB)"
+            echo "⚠️ App size approaching 150 MB limit" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "✅ App size within limits (< 100 MB)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Generate metrics JSON
+        if: always()
+        run: |
+          cat > "${RUNNER_TEMP}/metrics.json" <<EOF
+          {
+            "app_size_kb": ${{ steps.build.outputs.app_size_kb }},
+            "app_size_mb": "${{ steps.build.outputs.app_size_mb }}",
+            "warning_count": ${{ steps.build.outputs.warning_count }},
+            "archive_seconds": ${{ steps.build.outputs.archive_seconds }},
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "ref": "${{ github.ref }}",
+            "sha": "${{ github.sha }}"
+          }
+          EOF
+
+      - name: Save metrics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-build-metrics-baseline
+          path: ${{ runner.temp }}/metrics.json
+          retention-days: 90


### PR DESCRIPTION
## Summary
- PR/mainプッシュ時にiOSビルドメトリクス（バイナリサイズ・警告数・アーカイブ時間）を自動計測
- mainブランチとのサイズ差分をArtifacts経由で比較・Step Summaryに表示
- 150MB超過時はワークフロー失敗でPRブロック

## Test plan
- [ ] `gh pr checks` 全パス
- [ ] Step Summaryにメトリクスレポート表示
- [ ] ArtifactsにメトリクスJSON保存

🤖 Generated with [Claude Code](https://claude.com/claude-code)