### PR TITLE
ci(ios): Phase 19 マトリクスビルド対応

### DIFF
--- a/.github/workflows/ios-quality-gate.yml
+++ b/.github/workflows/ios-quality-gate.yml
@@ -50,19 +50,28 @@ jobs:
             --project FinalHourglass.xcodeproj \
             --schemes FinalHourglass \
             --format checkstyle
-
   build:
-    name: Build
-    runs-on: macos-latest
+    name: Build (iOS ${{ matrix.ios-version }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - xcode-version: '15.4'
+            runner: macos-14
+            simulator: 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5'
+            ios-version: '17.5'
+          - xcode-version: '16.2'
+            runner: macos-15
+            simulator: 'platform=iOS Simulator,name=iPhone 16,OS=18.2'
+            ios-version: '18.2'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode.app
-
-      - name: Install xcpretty
-        run: gem install xcpretty
+      - name: Setup iOS Environment
+        uses: ./.github/actions/setup-ios
+        with:
+          xcode-version: ${{ matrix.xcode-version }}
+          skip-cocoapods: 'true'
+          install-xcpretty: 'true'
 
       # ビルドログをファイルに保存して後続の警告チェックで使用
       # pipefailを有効化してxcodebuildの失敗を検知
@@ -73,9 +82,9 @@ jobs:
           xcodebuild build \
             -project FinalHourglass.xcodeproj \
             -scheme FinalHourglass \
-            -destination 'platform=iOS Simulator,name=iPhone 15 Pro' \
+            -destination '${{ matrix.simulator }}' \
             CODE_SIGNING_ALLOWED=NO \
-            2>&1 | tee build.log | xcpretty --color
+            2>&1 | tee build-ios${{ matrix.ios-version }}.log | xcpretty --color
 
       # 警告チェック: システム由来の警告（appintentsmetadataprocessor等）を除外し、
       # 残りの警告があればワークフローを失敗させる
@@ -83,7 +92,7 @@ jobs:
         run: |
           cd ios-apps/final-hourglass
           # 警告行を抽出し、システム由来の警告を除外（大文字小文字無視）
-          WARNINGS=$(grep -i "warning:" build.log | grep -vi "appintentsmetadataprocessor" || true)
+          WARNINGS=$(grep -i "warning:" build-ios${{ matrix.ios-version }}.log | grep -vi "appintentsmetadataprocessor" || true)
 
           if [ -n "$WARNINGS" ]; then
             echo "::error::ビルド警告が検出されました:"

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -26,37 +26,32 @@ on:
 
 jobs:
   test:
-    name: Unit Tests & Coverage
-    runs-on: macos-latest
+    name: Unit Tests & Coverage (iOS ${{ matrix.ios-version }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - xcode-version: '15.4'
+            runner: macos-14
+            simulator: 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5'
+            ios-version: '17.5'
+          - xcode-version: '16.2'
+            runner: macos-15
+            simulator: 'platform=iOS Simulator,name=iPhone 16,OS=18.2'
+            ios-version: '18.2'
     defaults:
       run:
         working-directory: ios-apps/final-hourglass
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Checkout iOS submodule
-        run: |
-          git clone https://x-access-token:${{ secrets.IOS_REPO_TOKEN }}@github.com/AIUELAB/final-hourglass-ios.git ios-apps/final-hourglass
-        working-directory: ${{ github.workspace }}
-
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode.app
-
-      - name: Cache CocoaPods
-        uses: actions/cache@v4
+      - name: Setup iOS Environment
+        uses: ./.github/actions/setup-ios
         with:
-          path: ios-apps/final-hourglass/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('ios-apps/final-hourglass/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-
-      - name: Install CocoaPods
-        run: pod install --repo-update
-
-      - name: Install xcpretty
-        run: gem install xcpretty
+          xcode-version: ${{ matrix.xcode-version }}
+          checkout-submodules: 'manual'
+          checkout-token: ${{ secrets.IOS_REPO_TOKEN }}
+          install-xcpretty: 'true'
 
       - name: Run Tests with Coverage
         run: |
@@ -64,9 +59,9 @@ jobs:
           xcodebuild test \
             -workspace FinalHourglass.xcworkspace \
             -scheme FinalHourglass \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination '${{ matrix.simulator }}' \
             -enableCodeCoverage YES \
-            -resultBundlePath TestResults.xcresult \
+            -resultBundlePath TestResults-ios${{ matrix.ios-version }}.xcresult \
             CODE_SIGNING_ALLOWED=NO \
             | xcpretty --color
 
@@ -77,7 +72,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # 全体カバレッジを抽出
-          TOTAL_COVERAGE=$(xcrun xccov view --report TestResults.xcresult 2>/dev/null | grep "FinalHourglass.app" | head -1 | grep -oE '[0-9]+\.[0-9]+%')
+          TOTAL_COVERAGE=$(xcrun xccov view --report TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep "FinalHourglass.app" | head -1 | grep -oE '[0-9]+\.[0-9]+%')
           echo "**Overall Coverage:** \`$TOTAL_COVERAGE\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
@@ -88,7 +83,7 @@ jobs:
           echo "|------|----------|--------|" >> $GITHUB_STEP_SUMMARY
 
           # 主要ファイルのカバレッジを抽出（閾値判定付き）
-          xcrun xccov view --report TestResults.xcresult 2>/dev/null | grep -E "^\s+/.*(LifeExpectancyCalculator|HealthScoreCalculator|Prefecture|UserModel|SupabaseManager|SupabaseConfig|EpisodeManager|CacheManager|AppStateManager|NotificationManager)\.swift" | while read line; do
+          xcrun xccov view --report TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep -E "^\s+/.*(LifeExpectancyCalculator|HealthScoreCalculator|Prefecture|UserModel|SupabaseManager|SupabaseConfig|EpisodeManager|CacheManager|AppStateManager|NotificationManager)\.swift" | while read line; do
             FILE=$(basename "$(echo "$line" | awk '{print $1}')")
             COV=$(echo "$line" | grep -oE '[0-9]+\.[0-9]+%')
             COV_NUM=$(echo "$COV" | grep -oE '[0-9]+\.[0-9]+')
@@ -111,17 +106,17 @@ jobs:
 
       # Phase 6: カバレッジ比較機能（PR時のみ）
       - name: Download Base Coverage
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.ios-version == '18.2'
         uses: dawidd6/action-download-artifact@v6
         continue-on-error: true
         with:
           workflow: ios-test.yml
           branch: main
-          name: coverage-report
+          name: coverage-report-ios-18.2
           path: base-coverage
 
       - name: Compare Coverage
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.ios-version == '18.2'
         id: coverage-compare
         run: |
           echo "📊 Comparing coverage with main branch..."
@@ -131,8 +126,8 @@ jobs:
           echo "current_coverage=$CURRENT_COV" >> $GITHUB_OUTPUT
 
           # ベースカバレッジを取得（存在する場合）
-          if [ -d "base-coverage" ] && [ -f "base-coverage/TestResults.xcresult" ]; then
-            BASE_COV=$(xcrun xccov view --report base-coverage/TestResults.xcresult 2>/dev/null | grep "FinalHourglass.app" | head -1 | grep -oE '[0-9]+\.[0-9]+' || echo "0")
+          if [ -d "base-coverage" ] && [ -f "base-coverage/TestResults-ios${{ matrix.ios-version }}.xcresult" ]; then
+            BASE_COV=$(xcrun xccov view --report base-coverage/TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep "FinalHourglass.app" | head -1 | grep -oE '[0-9]+\.[0-9]+' || echo "0")
           else
             BASE_COV="0"
             echo "⚠️ No base coverage found (first run or main branch has no coverage)"
@@ -162,7 +157,7 @@ jobs:
           fi
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.ios-version == '18.2'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -241,7 +236,7 @@ jobs:
 
       # Phase 6: READMEバッジ更新（mainブランチへのpush時のみ）
       - name: Update Coverage Badge
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.ios-version == '18.2'
         env:
           GH_TOKEN: ${{ secrets.GIST_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
@@ -283,7 +278,7 @@ jobs:
           FAILED=0
 
           # LifeExpectancyCalculator のカバレッジチェック
-          LIFE_COV=$(xcrun xccov view --report TestResults.xcresult 2>/dev/null | grep "LifeExpectancyCalculator.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          LIFE_COV=$(xcrun xccov view --report TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep "LifeExpectancyCalculator.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
           if [ -n "$LIFE_COV" ]; then
             if (( $(echo "$LIFE_COV < $THRESHOLD" | bc -l) )); then
               echo "❌ LifeExpectancyCalculator.swift: ${LIFE_COV}% < ${THRESHOLD}%"
@@ -296,7 +291,7 @@ jobs:
           fi
 
           # HealthScoreCalculator のカバレッジチェック
-          HEALTH_COV=$(xcrun xccov view --report TestResults.xcresult 2>/dev/null | grep "HealthScoreCalculator.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          HEALTH_COV=$(xcrun xccov view --report TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep "HealthScoreCalculator.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
           if [ -n "$HEALTH_COV" ]; then
             if (( $(echo "$HEALTH_COV < $THRESHOLD" | bc -l) )); then
               echo "❌ HealthScoreCalculator.swift: ${HEALTH_COV}% < ${THRESHOLD}%"
@@ -309,7 +304,7 @@ jobs:
           fi
 
           # UserModel のカバレッジチェック
-          USER_COV=$(xcrun xccov view --report TestResults.xcresult 2>/dev/null | grep "UserModel.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          USER_COV=$(xcrun xccov view --report TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep "UserModel.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
           if [ -n "$USER_COV" ]; then
             if (( $(echo "$USER_COV < $THRESHOLD" | bc -l) )); then
               echo "❌ UserModel.swift: ${USER_COV}% < ${THRESHOLD}%"
@@ -322,30 +317,30 @@ jobs:
           fi
 
           # SupabaseManager/Config は情報表示のみ（閾値チェックなし）
-          SUPA_COV=$(xcrun xccov view --report TestResults.xcresult 2>/dev/null | grep "SupabaseManager.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          SUPA_COV=$(xcrun xccov view --report TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep "SupabaseManager.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
           if [ -n "$SUPA_COV" ]; then
             echo "ℹ️ SupabaseManager.swift: ${SUPA_COV}% (monitored, no threshold)"
           fi
 
           # EpisodeManager/CacheManager は情報表示のみ（閾値チェックなし）
-          EPISODE_COV=$(xcrun xccov view --report TestResults.xcresult 2>/dev/null | grep "EpisodeManager.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          EPISODE_COV=$(xcrun xccov view --report TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep "EpisodeManager.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
           if [ -n "$EPISODE_COV" ]; then
             echo "ℹ️ EpisodeManager.swift: ${EPISODE_COV}% (monitored, no threshold)"
           fi
 
-          CACHE_COV=$(xcrun xccov view --report TestResults.xcresult 2>/dev/null | grep "CacheManager.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          CACHE_COV=$(xcrun xccov view --report TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep "CacheManager.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
           if [ -n "$CACHE_COV" ]; then
             echo "ℹ️ CacheManager.swift: ${CACHE_COV}% (monitored, no threshold)"
           fi
 
           # AppStateManager は情報表示のみ（閾値チェックなし）
-          APPSTATE_COV=$(xcrun xccov view --report TestResults.xcresult 2>/dev/null | grep "AppStateManager.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          APPSTATE_COV=$(xcrun xccov view --report TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep "AppStateManager.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
           if [ -n "$APPSTATE_COV" ]; then
             echo "ℹ️ AppStateManager.swift: ${APPSTATE_COV}% (monitored, no threshold)"
           fi
 
           # NotificationManager は情報表示のみ（閾値チェックなし）
-          NOTIFICATION_COV=$(xcrun xccov view --report TestResults.xcresult 2>/dev/null | grep "NotificationManager.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          NOTIFICATION_COV=$(xcrun xccov view --report TestResults-ios${{ matrix.ios-version }}.xcresult 2>/dev/null | grep "NotificationManager.swift" | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
           if [ -n "$NOTIFICATION_COV" ]; then
             echo "ℹ️ NotificationManager.swift: ${NOTIFICATION_COV}% (monitored, no threshold)"
           fi
@@ -372,9 +367,9 @@ jobs:
           echo "|--------|-----------|--------|" >> $GITHUB_STEP_SUMMARY
 
           # xcresultからパフォーマンスメトリクスを抽出
-          if [ -d "TestResults.xcresult" ]; then
+          if [ -d "TestResults-ios${{ matrix.ios-version }}.xcresult" ]; then
             # 起動時間チェック
-            LAUNCH_TIME=$(xcrun xcresulttool get --path TestResults.xcresult --format json 2>/dev/null | \
+            LAUNCH_TIME=$(xcrun xcresulttool get --path TestResults-ios${{ matrix.ios-version }}.xcresult --format json 2>/dev/null | \
               python3 -c "
           import json, sys
           try:
@@ -464,50 +459,49 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
-          path: ios-apps/final-hourglass/TestResults.xcresult
+          name: coverage-report-ios-${{ matrix.ios-version }}
+          path: ios-apps/final-hourglass/TestResults-ios${{ matrix.ios-version }}.xcresult
 
       - name: Upload Test Results
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
-          path: ios-apps/final-hourglass/TestResults.xcresult
+          name: test-results-ios-${{ matrix.ios-version }}
+          path: ios-apps/final-hourglass/TestResults-ios${{ matrix.ios-version }}.xcresult
 
   ui-test:
-    name: UI Tests (E2E)
-    runs-on: macos-latest
+    name: UI Tests (iOS ${{ matrix.ios-version }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - xcode-version: '15.4'
+            runner: macos-14
+            simulator: 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5'
+            ios-version: '17.5'
+            simulator-name: 'iPhone 15 Pro'
+          - xcode-version: '16.2'
+            runner: macos-15
+            simulator: 'platform=iOS Simulator,name=iPhone 16,OS=18.2'
+            ios-version: '18.2'
+            simulator-name: 'iPhone 16'
     defaults:
       run:
         working-directory: ios-apps/final-hourglass
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Checkout iOS submodule
-        run: |
-          git clone https://x-access-token:${{ secrets.IOS_REPO_TOKEN }}@github.com/AIUELAB/final-hourglass-ios.git ios-apps/final-hourglass
-        working-directory: ${{ github.workspace }}
-
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode.app
-
-      - name: Cache CocoaPods
-        uses: actions/cache@v4
+      - name: Setup iOS Environment
+        uses: ./.github/actions/setup-ios
         with:
-          path: ios-apps/final-hourglass/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('ios-apps/final-hourglass/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-
-      - name: Install CocoaPods
-        run: pod install --repo-update
+          xcode-version: ${{ matrix.xcode-version }}
+          checkout-submodules: 'manual'
+          checkout-token: ${{ secrets.IOS_REPO_TOKEN }}
 
       - name: Boot Simulator
         run: |
-          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone 16" | head -1 | grep -oE '[0-9A-F-]{36}')
+          DEVICE_ID=$(xcrun simctl list devices available | grep "${{ matrix.simulator-name }}" | head -1 | grep -oE '[0-9A-F-]{36}')
           xcrun simctl boot "$DEVICE_ID" || true
 
       - name: Run UI Tests with Retry
@@ -525,7 +519,7 @@ jobs:
             if xcodebuild test \
               -workspace FinalHourglass.xcworkspace \
               -scheme FinalHourglass \
-              -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+              -destination '${{ matrix.simulator }}' \
               -only-testing:FinalHourglassUITests \
               -retry-tests-on-failure \
               -test-iterations 2 \
@@ -582,7 +576,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ui-test-screenshots
+          name: ui-test-screenshots-ios-${{ matrix.ios-version }}
           path: ios-apps/final-hourglass/screenshots/
           if-no-files-found: ignore
 
@@ -590,7 +584,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ui-test-results
+          name: ui-test-results-ios-${{ matrix.ios-version }}
           path: ios-apps/final-hourglass/UITestResults_attempt*.xcresult
           if-no-files-found: ignore
 


### PR DESCRIPTION
## Summary
- ios-test.yml / ios-quality-gate.yml にマトリクス戦略を追加（iOS 17.5 + 18.2 の2構成）
- Xcode 15.4（macos-14）と Xcode 16.2（macos-15）で並列ビルド・テスト
- カバレッジPRコメント・バッジ更新は iOS 18.2 のみで実行（重複防止）
- アーティファクト名に iOS バージョンを付加して識別可能に

## Test plan
- [ ] `gh pr checks` で test×2, build×2 の4マトリクスジョブが並列実行されること
- [ ] 両iOS版でテスト成功、アーティファクトが別名で保存されること
- [ ] カバレッジPRコメント・バッジ更新が iOS 18.2 のみで実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア（メンテナンス）**
  * CI/CDワークフローを改善し、複数のiOSバージョン（iOS 17.5、18.2）とXcodeバージョンに対するマルチバリアント自動テストを実装しました。これにより、より幅広い環境での互換性検証が可能になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->