### PR TITLE
ci(ios): Phase 27 setup-ios action をリリースワークフローに適用

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -112,19 +112,11 @@ jobs:
           git clone https://x-access-token:${{ secrets.IOS_REPO_TOKEN }}@github.com/AIUELAB/final-hourglass-ios.git ios-apps/final-hourglass
         working-directory: ${{ github.workspace }}
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode.app
-
-      - name: Cache CocoaPods
-        uses: actions/cache@v4
+      - name: Setup iOS
+        uses: ./.github/actions/setup-ios
         with:
-          path: ios-apps/final-hourglass/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('ios-apps/final-hourglass/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-
-      - name: Install CocoaPods
-        run: pod install --repo-update
+          install-cocoapods: 'true'
+          cache-derived-data: 'true'
 
       - name: Install App Store Connect API Key
         env:


### PR DESCRIPTION
## Summary
- リリースワークフロー(`ios-release.yml`)の手動3ステップ（Xcode選択・CocoaPodsキャッシュ・CocoaPodsインストール）を共通 `setup-ios` composite action に統合
- CI/テスト用ワークフローと同じ setup-ios action を使用し、保守性・一貫性を向上

## Test plan
- [ ] `ios-release.yml` の YAML 構文が正しいこと（pre-commit で検証済み）
- [ ] setup-ios action のパラメータ（`install-cocoapods`, `cache-derived-data`）が正しく設定されていること
- [ ] リリースビルドが正常に実行されること（次回リリース時に確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * iOSリリースワークフローを最適化しました。ビルド・アーカイブプロセスを簡素化し、CocoaPodsのセットアップと派生データのキャッシュを統合して効率を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->