### PR TITLE
ci(ios): Phase 28 セキュリティ強化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,30 @@ updates:
     prefix: ci
     include: scope
 
+  # Swift Package Manager (iOS dependencies)
+- package-ecosystem: swift
+  directory: /ios-apps/final-hourglass
+  schedule:
+    interval: weekly
+    day: monday
+    time: 09:00
+    timezone: Asia/Tokyo
+  open-pull-requests-limit: 10
+  reviewers:
+  - ios-team
+  labels:
+  - dependencies
+  - swift
+  commit-message:
+    prefix: chore
+    prefix-development: chore
+    include: scope
+  groups:
+    swift-testing:
+      patterns:
+      - '*Test*'
+      - '*Mock*'
+
   # Docker
 - package-ecosystem: docker
   directory: /

--- a/.github/workflows/ios-quality-gate.yml
+++ b/.github/workflows/ios-quality-gate.yml
@@ -63,6 +63,44 @@ jobs:
             --schemes FinalHourglass \
             --format checkstyle
 
+  dependency-audit:
+    name: Dependency Audit
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install cocoapods-audit
+        run: gem install cocoapods-audit --no-document
+
+      - name: Run CocoaPods Audit
+        run: |
+          cd ios-apps/final-hourglass
+          if [ -f Podfile.lock ]; then
+            echo "## 🔍 CocoaPods Dependency Audit" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            if pod audit 2>&1 | tee audit_result.txt; then
+              echo "✅ No known vulnerabilities found" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "⚠️ Vulnerabilities detected:" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              cat audit_result.txt >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              exit 1
+            fi
+          else
+            echo "ℹ️ No Podfile.lock found - skipping CocoaPods audit" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Check Swift Package Resolved
+        run: |
+          cd ios-apps/final-hourglass
+          if [ -f Package.resolved ] || [ -f *.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved ]; then
+            echo "### Swift Package Dependencies" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Swift Package resolution file found" >> $GITHUB_STEP_SUMMARY
+          fi
+
   build:
     name: Build
     runs-on: macos-latest

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -79,6 +79,57 @@ jobs:
           fi
           echo "✅ Running on main branch"
 
+      - name: Validate Required Secrets
+        env:
+          HAS_CERT: ${{ secrets.DISTRIBUTION_CERTIFICATE_BASE64 != '' }}
+          HAS_CERT_PW: ${{ secrets.DISTRIBUTION_CERTIFICATE_PASSWORD != '' }}
+          HAS_KEYCHAIN_PW: ${{ secrets.KEYCHAIN_PASSWORD != '' }}
+          HAS_PROFILE: ${{ secrets.PROVISIONING_PROFILE_BASE64 != '' }}
+          HAS_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 != '' }}
+          HAS_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID != '' }}
+          HAS_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID != '' }}
+          HAS_REPO_TOKEN: ${{ secrets.IOS_REPO_TOKEN != '' }}
+        run: |
+          MISSING=""
+          DRY_RUN=false
+
+          # dry-run判定: 署名証明書がなければdry-runモード
+          if [ "$HAS_CERT" != "true" ]; then
+            DRY_RUN=true
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "⚠️ Running in dry-run mode (signing secrets not configured)"
+            echo "The following secrets are missing (expected for dry-run):"
+            [ "$HAS_CERT" != "true" ] && echo "  - DISTRIBUTION_CERTIFICATE_BASE64"
+            [ "$HAS_CERT_PW" != "true" ] && echo "  - DISTRIBUTION_CERTIFICATE_PASSWORD"
+            [ "$HAS_KEYCHAIN_PW" != "true" ] && echo "  - KEYCHAIN_PASSWORD"
+            [ "$HAS_PROFILE" != "true" ] && echo "  - PROVISIONING_PROFILE_BASE64"
+            [ "$HAS_API_KEY" != "true" ] && echo "  - APP_STORE_CONNECT_API_KEY_BASE64"
+            [ "$HAS_API_KEY_ID" != "true" ] && echo "  - APP_STORE_CONNECT_API_KEY_ID"
+            [ "$HAS_API_ISSUER" != "true" ] && echo "  - APP_STORE_CONNECT_API_ISSUER_ID"
+            exit 0
+          fi
+
+          # 本番モード: 全Secrets必須
+          [ "$HAS_CERT" != "true" ] && MISSING="$MISSING DISTRIBUTION_CERTIFICATE_BASE64"
+          [ "$HAS_CERT_PW" != "true" ] && MISSING="$MISSING DISTRIBUTION_CERTIFICATE_PASSWORD"
+          [ "$HAS_KEYCHAIN_PW" != "true" ] && MISSING="$MISSING KEYCHAIN_PASSWORD"
+          [ "$HAS_PROFILE" != "true" ] && MISSING="$MISSING PROVISIONING_PROFILE_BASE64"
+          [ "$HAS_API_KEY" != "true" ] && MISSING="$MISSING APP_STORE_CONNECT_API_KEY_BASE64"
+          [ "$HAS_API_KEY_ID" != "true" ] && MISSING="$MISSING APP_STORE_CONNECT_API_KEY_ID"
+          [ "$HAS_API_ISSUER" != "true" ] && MISSING="$MISSING APP_STORE_CONNECT_API_ISSUER_ID"
+          [ "$HAS_REPO_TOKEN" != "true" ] && MISSING="$MISSING IOS_REPO_TOKEN"
+
+          if [ -n "$MISSING" ]; then
+            echo "❌ Missing required secrets for production release:"
+            for SECRET in $MISSING; do
+              echo "  - $SECRET"
+            done
+            exit 1
+          fi
+          echo "✅ All required secrets are configured"
+
       - name: Validation Summary
         run: |
           echo "## ✅ Release Validation Passed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Dependabotに Swift Package Manager エコシステムを追加（`/ios-apps/final-hourglass` ディレクトリ対象）
- `ios-quality-gate.yml` に `dependency-audit` ジョブを追加（CocoaPods脆弱性スキャン、既存3ジョブと並列実行）
- `ios-release.yml` の `validate` ジョブに必須Secrets事前検証ステップを追加（dry-runモード時はスキップ）

## Test plan
- [x] YAML lint通過（pre-commit hook: `check yaml` + `Pretty format YAML`）
- [x] GitHub Workflow Validation通過（pre-commit hook: `Validate GitHub Workflows`）
- [ ] CIが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)