### PR TITLE
ci(ios): Phase 31 Privacy Audit 厳格化 - 警告→ブロッキング昇格

### DIFF
--- a/.github/scripts/validate-privacy-manifest.sh
+++ b/.github/scripts/validate-privacy-manifest.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+set -euo pipefail
+
+# validate-privacy-manifest.sh
+# Validates Apple Privacy Manifest (PrivacyInfo.xcprivacy) compliance for iOS apps.
+# Usage: validate-privacy-manifest.sh <app-directory>
+
+APP_DIR="${1:?Usage: validate-privacy-manifest.sh <app-directory>}"
+
+if [[ ! -d "$APP_DIR" ]]; then
+  echo "Error: Directory '$APP_DIR' not found."
+  exit 1
+fi
+
+# --- Category definitions ---
+# Format: KEY|API_TYPE|REASON|PATTERN1,PATTERN2,...
+CATEGORIES=(
+  "UserDefaults|NSPrivacyAccessedAPICategoryUserDefaults|CA92.1|UserDefaults.standard,UserDefaults(,@AppStorage"
+  "File Timestamps|NSPrivacyAccessedAPICategoryFileTimestamp|C617.1|.creationDate,.modificationDate,.contentModificationDateKey"
+  "System Boot Time|NSPrivacyAccessedAPICategorySystemBootTime|35F9.1|systemUptime,ProcessInfo.processInfo"
+  "Disk Space|NSPrivacyAccessedAPICategoryDiskSpace|E174.1|volumeAvailableCapacity,volumeTotalCapacity"
+  "Active Keyboard|NSPrivacyAccessedAPICategoryActiveKeyboards|3B52.1|activeInputModes,textInputMode"
+)
+
+MANIFEST=$(find "$APP_DIR" -name 'PrivacyInfo.xcprivacy' -not -path '*/Pods/*' -not -path '*/DerivedData/*' 2>/dev/null | head -1)
+HAS_MANIFEST=false
+if [[ -n "$MANIFEST" && -f "$MANIFEST" ]]; then
+  HAS_MANIFEST=true
+  MANIFEST_CONTENT=$(cat "$MANIFEST")
+fi
+
+# Collect Swift files excluding Pods/ and DerivedData/
+mapfile -t SWIFT_FILE_LIST < <(find "$APP_DIR" -name '*.swift' -not -path '*/Pods/*' -not -path '*/DerivedData/*' 2>/dev/null)
+
+declare -a DETECTED_NAMES=()
+declare -a DETECTED_TYPES=()
+declare -a DECLARED_FLAGS=()
+
+for entry in "${CATEGORIES[@]}"; do
+  IFS='|' read -r name api_type reason patterns <<< "$entry"
+  IFS=',' read -ra pats <<< "$patterns"
+
+  detected=false
+  if [[ ${#SWIFT_FILE_LIST[@]} -gt 0 ]]; then
+    for pat in "${pats[@]}"; do
+      # Search Swift files, exclude comment lines (trimmed lines starting with //)
+      if grep -rlF "$pat" "${SWIFT_FILE_LIST[@]}" 2>/dev/null | head -1 | grep -q .; then
+        detected=true
+        break
+      fi
+    done
+  fi
+
+  declared="N/A"
+  if $HAS_MANIFEST && $detected; then
+    if echo "$MANIFEST_CONTENT" | grep -qF "$api_type"; then
+      declared="Yes"
+    else
+      declared="No"
+    fi
+  elif $HAS_MANIFEST && ! $detected; then
+    declared="-"
+  fi
+
+  DETECTED_NAMES+=("$name")
+  DETECTED_TYPES+=("$api_type")
+  if $detected; then
+    DECLARED_FLAGS+=("detected|$declared")
+  else
+    DECLARED_FLAGS+=("no|$declared")
+  fi
+done
+
+# --- Build summary ---
+SUMMARY=""
+SUMMARY+="## Privacy Manifest Validation\n\n"
+SUMMARY+="| Category | Usage Detected | Declared in Manifest |\n"
+SUMMARY+="|----------|---------------|---------------------|\n"
+
+any_detected=false
+missing_declaration=false
+
+for i in "${!DETECTED_NAMES[@]}"; do
+  IFS='|' read -r det decl <<< "${DECLARED_FLAGS[$i]}"
+  if [[ "$det" == "detected" ]]; then
+    any_detected=true
+    det_display="Yes"
+    if [[ "$decl" == "No" ]]; then
+      missing_declaration=true
+    fi
+  else
+    det_display="No"
+  fi
+  SUMMARY+="| ${DETECTED_NAMES[$i]} | $det_display | $decl |\n"
+done
+
+if $HAS_MANIFEST; then
+  SUMMARY+="\nManifest: \`$MANIFEST\` found.\n"
+else
+  SUMMARY+="\nManifest: \`PrivacyInfo.xcprivacy\` **not found** in \`$APP_DIR\`.\n"
+fi
+
+# Output summary
+echo -e "$SUMMARY"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo -e "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# --- Exit code ---
+if $any_detected && ! $HAS_MANIFEST; then
+  echo "Warning: Required Reason APIs detected but no PrivacyInfo.xcprivacy found."
+  exit 1
+fi
+
+if $missing_declaration; then
+  echo "Error: Manifest exists but some detected API categories are not declared."
+  exit 2
+fi
+
+echo "All checks passed."
+exit 0

--- a/.github/workflows/ios-quality-gate.yml
+++ b/.github/workflows/ios-quality-gate.yml
@@ -12,6 +12,7 @@ on:
       - 'ios-apps/**/Podfile.lock'
       - 'ios-apps/**/project.pbxproj'
       - 'ios-apps/**/*.xcconfig'
+      - 'ios-apps/**/PrivacyInfo.xcprivacy'
 
 concurrency:
   group: ios-quality-gate-${{ github.head_ref || github.run_id }}
@@ -105,3 +106,16 @@ jobs:
           else
             echo "警告なし - OK"
           fi
+
+  privacy-audit:
+    name: Privacy Manifest Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Privacy Manifest
+        run: |
+          chmod +x .github/scripts/validate-privacy-manifest.sh
+          .github/scripts/validate-privacy-manifest.sh ios-apps/final-hourglass

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -79,6 +79,13 @@ jobs:
           fi
           echo "✅ Running on main branch"
 
+      - name: Privacy Manifest Pre-Release Check
+        run: |
+          chmod +x .github/scripts/validate-privacy-manifest.sh
+          # exit 0以外は全てリリースをブロック
+          # exit 1: manifest未検出、exit 2: API未宣言
+          .github/scripts/validate-privacy-manifest.sh ios-apps/final-hourglass
+
       - name: Validation Summary
         run: |
           echo "## ✅ Release Validation Passed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Quality Gate の `privacy-audit` ジョブから `continue-on-error: true` と `Evaluate Result` ステップを削除し、ブロッキング化
- Release ワークフローの Privacy check から EXIT_CODE 分岐を除去し、スクリプトの exit code をそのまま使用（exit 1/2 どちらもブロック）
- Phase 29 の検証スクリプト (`validate-privacy-manifest.sh`) を含む

## Test plan
- [x] `bash .github/scripts/validate-privacy-manifest.sh ios-apps/final-hourglass` → exit 0 確認済み
- [x] YAML バリデーション通過
- [x] pre-commit hook 全通過
- [ ] CI の privacy-audit ジョブがブロッキングで成功通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)