### PR TITLE
fix(ios-ci): Restore files lost in cascading rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,30 @@ updates:
     prefix: ci
     include: scope
 
+  # Swift Package Manager (iOS dependencies)
+- package-ecosystem: swift
+  directory: /ios-apps/final-hourglass
+  schedule:
+    interval: weekly
+    day: monday
+    time: 09:00
+    timezone: Asia/Tokyo
+  open-pull-requests-limit: 10
+  reviewers:
+  - ios-team
+  labels:
+  - dependencies
+  - swift
+  commit-message:
+    prefix: chore
+    prefix-development: chore
+    include: scope
+  groups:
+    swift-testing:
+      patterns:
+      - '*Test*'
+      - '*Mock*'
+
   # Docker
 - package-ecosystem: docker
   directory: /
@@ -98,6 +122,25 @@ updates:
   - docker
   commit-message:
     prefix: build
+    include: scope
+
+  # CocoaPods (iOS dependencies)
+  # Note: DependabotはCocoPodsを直接サポートしないため、
+  # bundlerエコシステムでGemfile経由の間接監視。
+  # ワークフロー側(ios-dependency-security.yml)でPod固有スキャンを実施。
+- package-ecosystem: bundler
+  directory: /ios-apps/final-hourglass
+  schedule:
+    interval: weekly
+    day: monday
+    time: 09:00
+    timezone: Asia/Tokyo
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  - ios
+  commit-message:
+    prefix: chore
     include: scope
 
 # Security updates configuration

--- a/.github/scripts/validate-privacy-manifest.sh
+++ b/.github/scripts/validate-privacy-manifest.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+set -euo pipefail
+
+# validate-privacy-manifest.sh
+# Validates Apple Privacy Manifest (PrivacyInfo.xcprivacy) compliance for iOS apps.
+# Usage: validate-privacy-manifest.sh <app-directory>
+
+APP_DIR="${1:?Usage: validate-privacy-manifest.sh <app-directory>}"
+
+if [[ ! -d "$APP_DIR" ]]; then
+  echo "Error: Directory '$APP_DIR' not found."
+  exit 1
+fi
+
+# --- Category definitions ---
+# Format: KEY|API_TYPE|REASON|PATTERN1,PATTERN2,...
+CATEGORIES=(
+  "UserDefaults|NSPrivacyAccessedAPICategoryUserDefaults|CA92.1|UserDefaults.standard,UserDefaults(,@AppStorage"
+  "File Timestamps|NSPrivacyAccessedAPICategoryFileTimestamp|C617.1|.creationDate,.modificationDate,.contentModificationDateKey"
+  "System Boot Time|NSPrivacyAccessedAPICategorySystemBootTime|35F9.1|systemUptime,ProcessInfo.processInfo"
+  "Disk Space|NSPrivacyAccessedAPICategoryDiskSpace|E174.1|volumeAvailableCapacity,volumeTotalCapacity"
+  "Active Keyboard|NSPrivacyAccessedAPICategoryActiveKeyboards|3B52.1|activeInputModes,textInputMode"
+)
+
+MANIFEST=$(find "$APP_DIR" -name 'PrivacyInfo.xcprivacy' -not -path '*/Pods/*' -not -path '*/DerivedData/*' 2>/dev/null | head -1)
+HAS_MANIFEST=false
+if [[ -n "$MANIFEST" && -f "$MANIFEST" ]]; then
+  HAS_MANIFEST=true
+  MANIFEST_CONTENT=$(cat "$MANIFEST")
+fi
+
+# Collect Swift files excluding Pods/ and DerivedData/
+mapfile -t SWIFT_FILE_LIST < <(find "$APP_DIR" -name '*.swift' -not -path '*/Pods/*' -not -path '*/DerivedData/*' 2>/dev/null)
+
+declare -a DETECTED_NAMES=()
+declare -a DETECTED_TYPES=()
+declare -a DECLARED_FLAGS=()
+
+for entry in "${CATEGORIES[@]}"; do
+  IFS='|' read -r name api_type reason patterns <<< "$entry"
+  IFS=',' read -ra pats <<< "$patterns"
+
+  detected=false
+  if [[ ${#SWIFT_FILE_LIST[@]} -gt 0 ]]; then
+    for pat in "${pats[@]}"; do
+      # Search Swift files, exclude comment lines (trimmed lines starting with //)
+      if grep -rlF "$pat" "${SWIFT_FILE_LIST[@]}" 2>/dev/null | head -1 | grep -q .; then
+        detected=true
+        break
+      fi
+    done
+  fi
+
+  declared="N/A"
+  if $HAS_MANIFEST && $detected; then
+    if echo "$MANIFEST_CONTENT" | grep -qF "$api_type"; then
+      declared="Yes"
+    else
+      declared="No"
+    fi
+  elif $HAS_MANIFEST && ! $detected; then
+    declared="-"
+  fi
+
+  DETECTED_NAMES+=("$name")
+  DETECTED_TYPES+=("$api_type")
+  if $detected; then
+    DECLARED_FLAGS+=("detected|$declared")
+  else
+    DECLARED_FLAGS+=("no|$declared")
+  fi
+done
+
+# --- Build summary ---
+SUMMARY=""
+SUMMARY+="## Privacy Manifest Validation\n\n"
+SUMMARY+="| Category | Usage Detected | Declared in Manifest |\n"
+SUMMARY+="|----------|---------------|---------------------|\n"
+
+any_detected=false
+missing_declaration=false
+
+for i in "${!DETECTED_NAMES[@]}"; do
+  IFS='|' read -r det decl <<< "${DECLARED_FLAGS[$i]}"
+  if [[ "$det" == "detected" ]]; then
+    any_detected=true
+    det_display="Yes"
+    if [[ "$decl" == "No" ]]; then
+      missing_declaration=true
+    fi
+  else
+    det_display="No"
+  fi
+  SUMMARY+="| ${DETECTED_NAMES[$i]} | $det_display | $decl |\n"
+done
+
+if $HAS_MANIFEST; then
+  SUMMARY+="\nManifest: \`$MANIFEST\` found.\n"
+else
+  SUMMARY+="\nManifest: \`PrivacyInfo.xcprivacy\` **not found** in \`$APP_DIR\`.\n"
+fi
+
+# Output summary
+echo -e "$SUMMARY"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  echo -e "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# --- Exit code ---
+if $any_detected && ! $HAS_MANIFEST; then
+  echo "Warning: Required Reason APIs detected but no PrivacyInfo.xcprivacy found."
+  exit 1
+fi
+
+if $missing_declaration; then
+  echo "Error: Manifest exists but some detected API categories are not declared."
+  exit 2
+fi
+
+echo "All checks passed."
+exit 0

--- a/.github/workflows/ios-build-metrics.yml
+++ b/.github/workflows/ios-build-metrics.yml
@@ -1,0 +1,193 @@
+name: iOS Build Metrics
+
+on:
+  pull_request:
+    paths:
+      - 'ios-apps/**/*.swift'
+      - 'ios-apps/**/Podfile'
+      - 'ios-apps/**/Podfile.lock'
+      - 'ios-apps/**/*.xcodeproj/**'
+      - 'ios-apps/**/*.xcworkspace/**'
+  push:
+    branches: [main]
+    paths:
+      - 'ios-apps/**/*.swift'
+      - 'ios-apps/**/Podfile'
+      - 'ios-apps/**/Podfile.lock'
+      - 'ios-apps/**/*.xcodeproj/**'
+      - 'ios-apps/**/*.xcworkspace/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-metrics:
+    runs-on: macos-15
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ios-apps/final-hourglass
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: ios-apps/final-hourglass/Pods
+          key: pods-${{ hashFiles('ios-apps/final-hourglass/Podfile.lock') }}
+          restore-keys: pods-
+
+      - name: Install CocoaPods dependencies
+        run: pod install --repo-update
+
+      - name: Build archive and capture metrics
+        id: build
+        run: |
+          set -euo pipefail
+
+          ARCHIVE_PATH="${RUNNER_TEMP}/FinalHourglass.xcarchive"
+          BUILD_LOG="${RUNNER_TEMP}/build.log"
+
+          # Record start time
+          START_TIME=$(date +%s)
+
+          # Build archive, tee output to log
+          xcodebuild archive \
+            -workspace FinalHourglass.xcworkspace \
+            -scheme FinalHourglass \
+            -configuration Release \
+            -archivePath "$ARCHIVE_PATH" \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            2>&1 | tee "$BUILD_LOG"
+
+          END_TIME=$(date +%s)
+          ARCHIVE_SECONDS=$((END_TIME - START_TIME))
+
+          # Calculate app bundle size
+          APP_PATH=$(find "$ARCHIVE_PATH/Products/Applications" -name "*.app" -maxdepth 1 | head -1)
+          if [ -n "$APP_PATH" ]; then
+            SIZE_BYTES=$(du -sk "$APP_PATH" | cut -f1)
+            SIZE_KB=$SIZE_BYTES
+            SIZE_MB=$(echo "scale=1; $SIZE_KB / 1024" | bc)
+          else
+            echo "::error::No .app bundle found in archive"
+            exit 1
+          fi
+
+          # Count build warnings
+          WARNING_COUNT=$(grep -c "warning:" "$BUILD_LOG" || true)
+
+          # Export outputs
+          echo "app_size_mb=$SIZE_MB" >> "$GITHUB_OUTPUT"
+          echo "app_size_kb=$SIZE_KB" >> "$GITHUB_OUTPUT"
+          echo "warning_count=$WARNING_COUNT" >> "$GITHUB_OUTPUT"
+          echo "archive_seconds=$ARCHIVE_SECONDS" >> "$GITHUB_OUTPUT"
+
+      - name: Download baseline metrics
+        id: baseline
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: ios-build-metrics-baseline
+          branch: main
+          workflow: ios-build-metrics.yml
+          path: ${{ runner.temp }}/baseline
+          if_no_artifact_found: warn
+
+      - name: Calculate size delta
+        id: delta
+        run: |
+          CURRENT_KB=${{ steps.build.outputs.app_size_kb }}
+          BASELINE_FILE="${RUNNER_TEMP}/baseline/metrics.json"
+
+          if [ -f "$BASELINE_FILE" ]; then
+            BASELINE_KB=$(jq -r '.app_size_kb' "$BASELINE_FILE")
+            DELTA_KB=$((CURRENT_KB - BASELINE_KB))
+            if [ "$BASELINE_KB" -gt 0 ]; then
+              DELTA_PCT=$(echo "scale=1; $DELTA_KB * 100 / $BASELINE_KB" | bc)
+            else
+              DELTA_PCT="N/A"
+            fi
+
+            if [ "$DELTA_KB" -ge 0 ]; then
+              DELTA_DISPLAY="+$(echo "scale=1; $DELTA_KB / 1024" | bc) MB (+${DELTA_PCT}%)"
+            else
+              DELTA_DISPLAY="$(echo "scale=1; $DELTA_KB / 1024" | bc) MB (${DELTA_PCT}%)"
+            fi
+            echo "delta_display=$DELTA_DISPLAY" >> "$GITHUB_OUTPUT"
+            echo "has_baseline=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "delta_display=—" >> "$GITHUB_OUTPUT"
+            echo "has_baseline=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate metrics report
+        run: |
+          SIZE_MB="${{ steps.build.outputs.app_size_mb }}"
+          WARNINGS="${{ steps.build.outputs.warning_count }}"
+          ARCHIVE_SEC="${{ steps.build.outputs.archive_seconds }}"
+          DELTA="${{ steps.delta.outputs.delta_display }}"
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## 📊 iOS Build Metrics
+
+          | Metric | Value | Change |
+          |--------|-------|--------|
+          | App Bundle Size | ${SIZE_MB} MB | ${DELTA} |
+          | Build Warnings | ${WARNINGS} | — |
+          | Archive Time | ${ARCHIVE_SEC}s | — |
+
+          EOF
+
+          # Threshold checks
+          SIZE_KB=${{ steps.build.outputs.app_size_kb }}
+          LIMIT_WARNING=$((100 * 1024))
+          LIMIT_FAIL=$((150 * 1024))
+
+          if [ "$SIZE_KB" -gt "$LIMIT_FAIL" ]; then
+            echo "::error::App size ${SIZE_MB} MB exceeds App Store limit (150 MB)"
+            echo "❌ **App size exceeds 150 MB App Store limit!**" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          elif [ "$SIZE_KB" -gt "$LIMIT_WARNING" ]; then
+            echo "::warning::App size ${SIZE_MB} MB approaching App Store limit (150 MB)"
+            echo "⚠️ App size approaching 150 MB limit" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "✅ App size within limits (< 100 MB)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Generate metrics JSON
+        if: always()
+        run: |
+          cat > "${RUNNER_TEMP}/metrics.json" <<EOF
+          {
+            "app_size_kb": ${{ steps.build.outputs.app_size_kb }},
+            "app_size_mb": "${{ steps.build.outputs.app_size_mb }}",
+            "warning_count": ${{ steps.build.outputs.warning_count }},
+            "archive_seconds": ${{ steps.build.outputs.archive_seconds }},
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "ref": "${{ github.ref }}",
+            "sha": "${{ github.sha }}"
+          }
+          EOF
+
+      - name: Save metrics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-build-metrics-baseline
+          path: ${{ runner.temp }}/metrics.json
+          retention-days: 90

--- a/.github/workflows/ios-dependency-security.yml
+++ b/.github/workflows/ios-dependency-security.yml
@@ -1,0 +1,185 @@
+# iOS Dependency Security - CocoaPods脆弱性スキャン
+name: iOS Dependency Security
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # 毎週月曜 09:00 JST
+  pull_request:
+    paths:
+      - 'ios-apps/**/Podfile'
+      - 'ios-apps/**/Podfile.lock'
+  push:
+    branches:
+      - main
+    paths:
+      - 'ios-apps/**/Podfile'
+      - 'ios-apps/**/Podfile.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: read
+
+jobs:
+  dependency-audit:
+    name: CocoaPods Security Audit
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: ios-apps/final-hourglass
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout iOS submodule
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          git submodule update --init --recursive ios-apps/final-hourglass
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install CocoaPods
+        run: gem install cocoapods
+
+      - name: Check outdated Pods
+        id: outdated
+        run: |
+          echo "## 📦 Outdated Pods" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          pod outdated 2>&1 | tee outdated.txt || true
+          cat outdated.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Extract Pod dependencies
+        id: extract
+        run: |
+          # Podfile.lockからPod名とバージョンを抽出
+          if [ -f Podfile.lock ]; then
+            echo "## 🔍 Installed Pods" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            grep -E '^\s+-\s+\w+' Podfile.lock | sed 's/.*- //' | head -50 | tee pods.txt
+            cat pods.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No Podfile.lock found"
+            echo "pods=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Query GitHub Advisory Database
+        id: advisory
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "## 🛡️ Security Advisory Check" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          CRITICAL_COUNT=0
+          HIGH_COUNT=0
+          MEDIUM_COUNT=0
+          LOW_COUNT=0
+          HAS_ISSUES=false
+
+          if [ -f pods.txt ]; then
+            while IFS= read -r line; do
+              # Pod名を抽出（バージョン番号を除去）
+              POD_NAME=$(echo "$line" | sed 's/[[:space:]]*(.*//' | xargs)
+              [ -z "$POD_NAME" ] && continue
+
+              # GitHub Advisory Database APIで照会
+              RESULT=$(gh api graphql -f query='
+                query($keyword: String!) {
+                  securityAdvisories(first: 5, keyword: $keyword, orderBy: {field: PUBLISHED_AT, direction: DESC}) {
+                    nodes {
+                      ghsaId
+                      summary
+                      severity
+                      publishedAt
+                      vulnerabilities(first: 5) {
+                        nodes {
+                          package {
+                            name
+                            ecosystem
+                          }
+                          vulnerableVersionRange
+                        }
+                      }
+                    }
+                  }
+                }
+              ' -f keyword="$POD_NAME" 2>/dev/null || echo '{"data":{"securityAdvisories":{"nodes":[]}}}')
+
+              # アドバイザリが見つかった場合
+              ADVISORY_COUNT=$(echo "$RESULT" | jq '.data.securityAdvisories.nodes | length' 2>/dev/null || echo "0")
+              if [ "$ADVISORY_COUNT" -gt 0 ]; then
+                echo "### ⚠️ $POD_NAME" >> "$GITHUB_STEP_SUMMARY"
+                echo "$RESULT" | jq -r '.data.securityAdvisories.nodes[] | "- **\(.severity)**: \(.summary) ([\(.ghsaId)](https://github.com/advisories/\(.ghsaId)))"' >> "$GITHUB_STEP_SUMMARY" 2>/dev/null
+                echo "" >> "$GITHUB_STEP_SUMMARY"
+
+                # 重要度カウント
+                CRITICAL_COUNT=$((CRITICAL_COUNT + $(echo "$RESULT" | jq '[.data.securityAdvisories.nodes[] | select(.severity == "CRITICAL")] | length' 2>/dev/null || echo "0")))
+                HIGH_COUNT=$((HIGH_COUNT + $(echo "$RESULT" | jq '[.data.securityAdvisories.nodes[] | select(.severity == "HIGH")] | length' 2>/dev/null || echo "0")))
+                MEDIUM_COUNT=$((MEDIUM_COUNT + $(echo "$RESULT" | jq '[.data.securityAdvisories.nodes[] | select(.severity == "MODERATE")] | length' 2>/dev/null || echo "0")))
+                LOW_COUNT=$((LOW_COUNT + $(echo "$RESULT" | jq '[.data.securityAdvisories.nodes[] | select(.severity == "LOW")] | length' 2>/dev/null || echo "0")))
+              fi
+            done < pods.txt
+          fi
+
+          # サマリー
+          echo "## 📊 Security Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Severity | Count |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 🔴 Critical | $CRITICAL_COUNT |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 🟠 High | $HIGH_COUNT |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 🟡 Medium | $MEDIUM_COUNT |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| 🔵 Low | $LOW_COUNT |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # CRITICAL/HIGHがあればfail
+          echo "critical_count=$CRITICAL_COUNT" >> "$GITHUB_OUTPUT"
+          echo "high_count=$HIGH_COUNT" >> "$GITHUB_OUTPUT"
+
+          if [ "$CRITICAL_COUNT" -gt 0 ] || [ "$HIGH_COUNT" -gt 0 ]; then
+            echo "🚨 **CRITICAL or HIGH severity vulnerabilities detected!**" >> "$GITHUB_STEP_SUMMARY"
+            echo "has_blocking_issues=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "✅ **No critical or high severity vulnerabilities found.**" >> "$GITHUB_STEP_SUMMARY"
+            echo "has_blocking_issues=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check Dependabot Alerts
+        id: dependabot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "## 🤖 Dependabot Alerts" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # Dependabotアラート取得
+          ALERTS=$(gh api repos/${{ github.repository }}/dependabot/alerts \
+            --jq '[.[] | select(.state == "open") | select(.dependency.package.ecosystem == "pip" | not) | {package: .dependency.package.name, severity: .security_advisory.severity, summary: .security_advisory.summary}]' \
+            2>/dev/null || echo "[]")
+
+          ALERT_COUNT=$(echo "$ALERTS" | jq 'length' 2>/dev/null || echo "0")
+
+          if [ "$ALERT_COUNT" -gt 0 ]; then
+            echo "| Package | Severity | Summary |" >> "$GITHUB_STEP_SUMMARY"
+            echo "|---------|----------|---------|" >> "$GITHUB_STEP_SUMMARY"
+            echo "$ALERTS" | jq -r '.[] | "| \(.package) | \(.severity) | \(.summary) |"' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "✅ No open Dependabot alerts for non-Python dependencies." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail on critical/high vulnerabilities
+        if: steps.advisory.outputs.has_blocking_issues == 'true'
+        run: |
+          echo "::error::CRITICAL or HIGH severity vulnerabilities detected in iOS dependencies."
+          echo "Critical: ${{ steps.advisory.outputs.critical_count }}, High: ${{ steps.advisory.outputs.high_count }}"
+          exit 1

--- a/.github/workflows/ios-quality-gate.yml
+++ b/.github/workflows/ios-quality-gate.yml
@@ -64,6 +64,44 @@ jobs:
             --schemes FinalHourglass \
             --format checkstyle
 
+  dependency-audit:
+    name: Dependency Audit
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install cocoapods-audit
+        run: gem install cocoapods-audit --no-document
+
+      - name: Run CocoaPods Audit
+        run: |
+          cd ios-apps/final-hourglass
+          if [ -f Podfile.lock ]; then
+            echo "## 🔍 CocoaPods Dependency Audit" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            if pod audit 2>&1 | tee audit_result.txt; then
+              echo "✅ No known vulnerabilities found" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "⚠️ Vulnerabilities detected:" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              cat audit_result.txt >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+              exit 1
+            fi
+          else
+            echo "ℹ️ No Podfile.lock found - skipping CocoaPods audit" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Check Swift Package Resolved
+        run: |
+          cd ios-apps/final-hourglass
+          if [ -f Package.resolved ] || [ -f *.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved ]; then
+            echo "### Swift Package Dependencies" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Swift Package resolution file found" >> $GITHUB_STEP_SUMMARY
+          fi
+
   build:
     name: Build
     runs-on: macos-latest

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -79,6 +79,64 @@ jobs:
           fi
           echo "✅ Running on main branch"
 
+      - name: Validate Required Secrets
+        env:
+          HAS_CERT: ${{ secrets.DISTRIBUTION_CERTIFICATE_BASE64 != '' }}
+          HAS_CERT_PW: ${{ secrets.DISTRIBUTION_CERTIFICATE_PASSWORD != '' }}
+          HAS_KEYCHAIN_PW: ${{ secrets.KEYCHAIN_PASSWORD != '' }}
+          HAS_PROFILE: ${{ secrets.PROVISIONING_PROFILE_BASE64 != '' }}
+          HAS_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 != '' }}
+          HAS_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID != '' }}
+          HAS_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID != '' }}
+          HAS_REPO_TOKEN: ${{ secrets.IOS_REPO_TOKEN != '' }}
+        run: |
+          MISSING=""
+          DRY_RUN=false
+
+          # dry-run判定: 署名証明書がなければdry-runモード
+          if [ "$HAS_CERT" != "true" ]; then
+            DRY_RUN=true
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "⚠️ Running in dry-run mode (signing secrets not configured)"
+            echo "The following secrets are missing (expected for dry-run):"
+            [ "$HAS_CERT" != "true" ] && echo "  - DISTRIBUTION_CERTIFICATE_BASE64"
+            [ "$HAS_CERT_PW" != "true" ] && echo "  - DISTRIBUTION_CERTIFICATE_PASSWORD"
+            [ "$HAS_KEYCHAIN_PW" != "true" ] && echo "  - KEYCHAIN_PASSWORD"
+            [ "$HAS_PROFILE" != "true" ] && echo "  - PROVISIONING_PROFILE_BASE64"
+            [ "$HAS_API_KEY" != "true" ] && echo "  - APP_STORE_CONNECT_API_KEY_BASE64"
+            [ "$HAS_API_KEY_ID" != "true" ] && echo "  - APP_STORE_CONNECT_API_KEY_ID"
+            [ "$HAS_API_ISSUER" != "true" ] && echo "  - APP_STORE_CONNECT_API_ISSUER_ID"
+            exit 0
+          fi
+
+          # 本番モード: 全Secrets必須
+          [ "$HAS_CERT" != "true" ] && MISSING="$MISSING DISTRIBUTION_CERTIFICATE_BASE64"
+          [ "$HAS_CERT_PW" != "true" ] && MISSING="$MISSING DISTRIBUTION_CERTIFICATE_PASSWORD"
+          [ "$HAS_KEYCHAIN_PW" != "true" ] && MISSING="$MISSING KEYCHAIN_PASSWORD"
+          [ "$HAS_PROFILE" != "true" ] && MISSING="$MISSING PROVISIONING_PROFILE_BASE64"
+          [ "$HAS_API_KEY" != "true" ] && MISSING="$MISSING APP_STORE_CONNECT_API_KEY_BASE64"
+          [ "$HAS_API_KEY_ID" != "true" ] && MISSING="$MISSING APP_STORE_CONNECT_API_KEY_ID"
+          [ "$HAS_API_ISSUER" != "true" ] && MISSING="$MISSING APP_STORE_CONNECT_API_ISSUER_ID"
+          [ "$HAS_REPO_TOKEN" != "true" ] && MISSING="$MISSING IOS_REPO_TOKEN"
+
+          if [ -n "$MISSING" ]; then
+            echo "❌ Missing required secrets for production release:"
+            for SECRET in $MISSING; do
+              echo "  - $SECRET"
+            done
+            exit 1
+          fi
+          echo "✅ All required secrets are configured"
+
+      - name: Privacy Manifest Pre-Release Check
+        run: |
+          chmod +x .github/scripts/validate-privacy-manifest.sh
+          # exit 0以外は全てリリースをブロック
+          # exit 1: manifest未検出、exit 2: API未宣言
+          .github/scripts/validate-privacy-manifest.sh ios-apps/final-hourglass
+
       - name: Validation Summary
         run: |
           echo "## ✅ Release Validation Passed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Restored 3 deleted workflow/script files (`ios-build-metrics.yml`, `ios-dependency-security.yml`, `validate-privacy-manifest.sh`)
- Restored Swift/bundler sections in `dependabot.yml`
- Restored `dependency-audit` job in `ios-quality-gate.yml`
- Restored secret validation + privacy manifest check in `ios-release.yml`

## Context
During sequential rebase of G2→G3→G4→G5 PRs (#47→#48→#49→#50→#46), later PRs deleted files added by earlier PRs due to diff against `origin/main` instead of the rebased branch tip.

## Test plan
- [x] YAML syntax validation passed
- [x] All 5 iOS workflow files exist
- [x] `validate-privacy-manifest.sh` exists and is executable
- [x] `dependabot.yml` contains Swift and bundler ecosystems
- [x] Pre-commit hooks passed (including GitHub Workflow validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS アプリケーションの自動検証ワークフローを追加（プライバシーマニフェスト、依存関係セキュリティ監査、ビルドメトリクス収集）
  * 週次の自動依存関係チェックと CocoaPods セキュリティスキャンを実装
  * リリースプロセスに必須秘密認証情報の検証とプライバシー適合性チェックを統合

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->