### PR TITLE
fix(ios-ci): Workflow quality improvements

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -3,6 +3,10 @@ name: Setup iOS Environment
 description: iOS CI共通のセットアップステップを集約
 
 inputs:
+  xcode-version:
+    description: 'Xcodeバージョン (例: Xcode_16.2.app)。未指定時は Xcode.app (latest)'
+    required: false
+    default: Xcode.app
   install-cocoapods:
     description: CocoaPodsをインストールするか
     required: false
@@ -25,7 +29,7 @@ runs:
   steps:
   - name: Select Xcode
     shell: bash
-    run: sudo xcode-select -s /Applications/Xcode.app
+    run: sudo xcode-select -s /Applications/${{ inputs.xcode-version }}
 
   - name: Cache CocoaPods
     if: inputs.install-cocoapods == 'true'

--- a/.github/workflows/ios-build-metrics.yml
+++ b/.github/workflows/ios-build-metrics.yml
@@ -36,18 +36,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
-
-      - name: Cache CocoaPods
-        uses: actions/cache@v4
+      - name: Setup iOS
+        uses: ./.github/actions/setup-ios
         with:
-          path: ios-apps/final-hourglass/Pods
-          key: pods-${{ hashFiles('ios-apps/final-hourglass/Podfile.lock') }}
-          restore-keys: pods-
-
-      - name: Install CocoaPods dependencies
-        run: pod install --repo-update
+          install-cocoapods: 'true'
 
       - name: Build archive and capture metrics
         id: build

--- a/.github/workflows/ios-quality-gate.yml
+++ b/.github/workflows/ios-quality-gate.yml
@@ -125,7 +125,7 @@ jobs:
           xcodebuild build \
             -project FinalHourglass.xcodeproj \
             -scheme FinalHourglass \
-            -destination 'platform=iOS Simulator,name=iPhone 15 Pro' \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
             CODE_SIGNING_ALLOWED=NO \
             2>&1 | tee build.log | xcpretty --color
 
@@ -144,3 +144,16 @@ jobs:
           else
             echo "警告なし - OK"
           fi
+
+  privacy-audit:
+    name: Privacy Manifest Audit
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Privacy Manifest
+        run: |
+          chmod +x .github/scripts/validate-privacy-manifest.sh
+          .github/scripts/validate-privacy-manifest.sh ios-apps/final-hourglass

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -167,7 +167,11 @@ jobs:
 
       - name: Checkout iOS submodule
         run: |
-          git clone https://x-access-token:${{ secrets.IOS_REPO_TOKEN }}@github.com/AIUELAB/final-hourglass-ios.git ios-apps/final-hourglass
+          git submodule update --init --recursive
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: url.https://x-access-token:${{ secrets.IOS_REPO_TOKEN }}@github.com/.insteadOf
+          GIT_CONFIG_VALUE_0: https://github.com/
         working-directory: ${{ github.workspace }}
 
       - name: Select Xcode
@@ -381,6 +385,8 @@ jobs:
 
           xcrun notarytool submit --help > /dev/null 2>&1 || true
 
+          # NOTE: altool is deprecated by Apple. Consider migrating to
+          # `xcrun notarytool` or the App Store Connect API in a future update.
           xcrun altool --upload-app \
             --type ios \
             --file "${{ runner.temp }}/FinalHourglass.ipa" \

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -76,7 +76,11 @@ jobs:
 
       - name: Checkout iOS submodule
         run: |
-          git clone https://x-access-token:${{ secrets.IOS_REPO_TOKEN }}@github.com/AIUELAB/final-hourglass-ios.git ios-apps/final-hourglass
+          git submodule update --init --recursive
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: url.https://x-access-token:${{ secrets.IOS_REPO_TOKEN }}@github.com/.insteadOf
+          GIT_CONFIG_VALUE_0: https://github.com/
         working-directory: ${{ github.workspace }}
 
       - name: Setup iOS
@@ -520,7 +524,11 @@ jobs:
 
       - name: Checkout iOS submodule
         run: |
-          git clone https://x-access-token:${{ secrets.IOS_REPO_TOKEN }}@github.com/AIUELAB/final-hourglass-ios.git ios-apps/final-hourglass
+          git submodule update --init --recursive
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: url.https://x-access-token:${{ secrets.IOS_REPO_TOKEN }}@github.com/.insteadOf
+          GIT_CONFIG_VALUE_0: https://github.com/
         working-directory: ${{ github.workspace }}
 
       - name: Setup iOS


### PR DESCRIPTION
## Summary
- **[CRITICAL]** `git clone` → `git submodule update --init --recursive` に統一（ios-test.yml 2箇所、ios-release.yml 1箇所）
- **[CRITICAL]** `ios-quality-gate.yml` に欠落していた Privacy Manifest Audit ジョブを追加（5ジョブ完成）
- **[MEDIUM]** `setup-ios` action に `xcode-version` input を追加し、Xcode バージョン管理を統一
- **[MEDIUM]** シミュレータ機種を `iPhone 16` に統一（quality-gate が `iPhone 15 Pro` だった）
- **[MEDIUM]** `ios-build-metrics.yml` を `setup-ios` action 経由に移行
- **[LOW]** `xcrun altool` 非推奨コメントを追記

## Test plan
- [ ] `git clone` が全ワークフローから除去されていること
- [ ] quality-gate に5ジョブ（swiftlint, periphery, dependency-audit, build, privacy-audit）が存在すること
- [ ] setup-ios action に `xcode-version` input が追加されていること
- [ ] 全ワークフローのシミュレータが `iPhone 16` に統一されていること
- [ ] CI全ジョブが通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Xcodeバージョンをカスタマイズ可能に
  * プライバシーマニフェスト監査を品質チェックに追加

* **更新**
  * ビルド環境をiPhone 16シミュレータに更新
  * サブモジュール初期化プロセスを改善
  * altoolツールの廃止予定通知を追加（今後の移行推奨）

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->