### PR TITLE
fix(ios-ci): Add missing .gitmodules for submodule configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ios-apps/final-hourglass"]
+	path = ios-apps/final-hourglass
+	url = https://github.com/AIUELAB/final-hourglass-ios.git


### PR DESCRIPTION
## Summary
- `.gitmodules` ファイルが欠落していたため、`git submodule update --init --recursive` が失敗していた
- iOS CI 全ワークフローおよび OpenSSF Scorecard が失敗する原因となっていた
- `.gitmodules` を追加し、`ios-apps/final-hourglass` submodule の設定を定義

## Test plan
- [x] `git submodule update --init --recursive` がローカルで成功することを確認
- [ ] iOS CI ワークフローが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * プロジェクト構成を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->