### PR TITLE
fix(epup): Phase 19 - B1/C1/C2違反修正

### DIFF
--- a/preserved/data/MASTER_EPISODES_CURRENT.csv
+++ b/preserved/data/MASTER_EPISODES_CURRENT.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65283e84754eabde0e5e3ffcbcff3283a4668653660d3909440760b219c640dc
-size 61824619
+oid sha256:003d93af62531c29ed3c453a55a1dd269ce380c52bea8190e49ccbc7f2ae55b8
+size 56724589

--- a/preserved/episode_database_dashboard_v11.html
+++ b/preserved/episode_database_dashboard_v11.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48ab48e6aa89c0428847e4eb91673ec3efd00fcac6be85d2fcb1ded28b74fa4e
-size 385930
+oid sha256:cae64cf267d385a21f1fa79aabed2ae9e2dff8fd351b3432780aba1b4e38b6cc
+size 385984

--- a/scripts/fix/fix_person_name_mismatch.py
+++ b/scripts/fix/fix_person_name_mismatch.py
@@ -4,19 +4,26 @@
 
 CSVのperson_nameとエピソード本文のリード文の人物名が不一致のエピソードを修正する。
 
+修正モード:
+1. CORRECTION_MAPベース: リード文の誤った名前を正しい名前に置換
+2. B1違反修正: テキストに人物名がない場合、冒頭に人物名を挿入
+
 Usage:
     # ドライラン（変更内容の確認のみ）
-    python scripts/fix_person_name_mismatch.py
+    python scripts/fix/fix_person_name_mismatch.py
 
     # 本番実行
-    python scripts/fix_person_name_mismatch.py --execute
+    python scripts/fix/fix_person_name_mismatch.py --execute
+
+    # B1違反のみ修正
+    python scripts/fix/fix_person_name_mismatch.py --b1-only --execute
 """
 
 import argparse
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, List, Tuple
 
 import pandas as pd
 
@@ -36,6 +43,108 @@ CORRECTION_MAP = {
     "コナー・マクデイビッド": "アイスホッケー・コナー・マクデイビッド",
     "L'Arc〜en〜CielのKen": "ken",
 }
+
+# B1違反対象のエピソードID（テキストに人物名がないケース）
+# detect_all_inconsistencies.py で検出された B1_name_not_in_text 違反
+B1_VIOLATION_IDS = [
+    "EP-260117001544165",
+    "EP-260118072321768",
+    "EP-260118100239523",
+    "EP-260118072308914",
+    "EP-260118094839912",
+    "EP-260118100230689",
+    "EP-260116232909031",
+    "EP-260116232909042",
+    "EP-260116232908180",
+    "EP-260118093404973",
+    "EP-260118072310704",
+    "EP-260118072316068",
+    "EP-260118093044514",
+    "EP-260118072301203",
+    "EP-260118072300081",
+    "EP-260118072303552",
+    "EP-260118072300027",
+    "EP-260118072741676",
+    "EP-260118072327770",
+    "EP-260118072315883",
+    "EP-260118072306106",
+    "EP-260116232910139",
+    "EP-260116235011744",
+    "EP-260118072310762",
+    "EP-260118072327236",
+    "EP-260118093227099",
+    "EP-260118100711636",
+    "EP-260118072300235",
+    "EP-260118071717400",
+    "EP-260118093413661",
+    "EP-260118072318654",
+    "EP-260118072326517",
+    "EP-260118072804966",
+    "EP-260118072157622",
+    "EP-260116231610527",
+    "EP-260117002321212",
+    "EP-260118072305799",
+    "EP-260116235010954",
+    "EP-260116232909867",
+    "EP-260116235458266",
+    "EP-260116232910828",
+    "EP-260116213255305",
+    "EP-260118071228944",
+    "EP-260118072312485",
+    "EP-260117000725169",
+    "EP-260116231608178",
+    "EP-260118071155334",
+    "EP-260118072302187",
+    "EP-260118101139094",
+    "EP-260118092918181",
+    "EP-260118073222629",
+    "EP-260118070802591",
+    "EP-260118070802821",
+    "EP-260118070802604",
+    "EP-260118070803338",
+    "EP-260118100711641",
+    "EP-260118072320006",
+    "EP-260118072311003",
+    "EP-260116232908679",
+    "EP-260118072304059",
+    "EP-260116235829050",
+    "EP-260116235458385",
+    "EP-260118072305111",
+    "EP-260116235828473",
+    "EP-260117000724677",
+    "EP-260116235011767",
+    "EP-260116231610922",
+    "EP-260118101140618",
+    "EP-260118072309658",
+    "EP-260118072304290",
+    "EP-260118072312568",
+    "EP-260118071228714",
+    "EP-260118070838674",
+    "EP-260118072328559",
+    "EP-260118072323742",
+    "EP-260118072327060",
+    "EP-260118073222985",
+    "EP-260118072321170",
+    "EP-260118095859000",
+    "EP-260118071728906",
+    "EP-260118072322564",
+    "EP-260117001544494",
+    "EP-260118072320178",
+    "EP-260118093409462",
+    "EP-260118093118050",
+    "EP-260118072328194",
+    "EP-260118093118863",
+    "EP-2601161401370238",
+    "EP-2601161353220244",
+    "EP-2601161353220242",
+    "EP-2601161353220423",
+    "EP-2601161401370404",
+    "EP-2601161401370427",
+    "EP-260112014047311238",
+    "EP-260112014047311141",
+    "EP-260112014047311880",
+    "EP-260112014047311406",
+]
 
 
 def fix_lead_person_name(episode_text: str, wrong_name: str, correct_name: str) -> str:
@@ -150,6 +259,137 @@ def find_and_fix_mismatches(df: pd.DataFrame, dry_run: bool = True) -> Dict[str,
     return results
 
 
+def fix_b1_violations(df: pd.DataFrame, dry_run: bool = True) -> Dict[str, Any]:
+    """
+    B1違反（テキストに人物名がない）を修正
+
+    修正方法:
+    - 三人称エピソード: 「あなたと同じXX歳のとき、」の後に「{person_name}は」を挿入
+    - 一人称エピソード（僕は/私は等）: 削除（品質問題のため）
+
+    Args:
+        df: エピソードデータフレーム
+        dry_run: ドライランモード
+
+    Returns:
+        処理結果の詳細
+    """
+    # 一人称パターン（これで始まるエピソードは削除対象）
+    first_person_patterns = ["僕は", "僕が", "私は", "私が", "俺は", "俺が"]
+
+    results = {
+        "timestamp": datetime.now().isoformat(),
+        "total": len(B1_VIOLATION_IDS),
+        "fixed": 0,
+        "deleted": 0,
+        "skipped": 0,
+        "not_found": 0,
+        "changes": [],
+        "deletions": [],
+    }
+
+    # エピソードIDでインデックス作成
+    df_indexed = df.set_index("episode_id", drop=False)
+
+    for ep_id in B1_VIOLATION_IDS:
+        if ep_id not in df_indexed.index:
+            results["not_found"] += 1
+            continue
+
+        row = df_indexed.loc[ep_id]
+        person_name = str(row.get("person_name", ""))
+        episode_text = str(row.get("episode_text", ""))
+        age = str(row.get("age", ""))
+
+        # すでに人物名が含まれている場合はスキップ
+        if person_name in episode_text:
+            results["skipped"] += 1
+            continue
+
+        # テキストパターン: 「あなたと同じXX歳のとき、」で始まる
+        pattern = re.compile(r"^(あなたと同じ\d+歳のとき、)")
+        match = pattern.match(episode_text)
+
+        if not match:
+            print(f"⚠️ パターン不一致（{ep_id}）: {episode_text[:50]}...")
+            results["skipped"] += 1
+            continue
+
+        prefix = match.group(1)
+        rest = episode_text[match.end() :]
+
+        # 一人称エピソードかチェック
+        is_first_person = any(rest.startswith(fp) or f"、{fp}" in rest[:30] for fp in first_person_patterns)
+
+        if is_first_person:
+            # 一人称エピソードは削除
+            results["deletions"].append(
+                {
+                    "episode_id": ep_id,
+                    "person_name": person_name,
+                    "age": age,
+                    "reason": "一人称で記述されており、修正困難",
+                    "text_preview": episode_text[:100] + "..." if len(episode_text) > 100 else episode_text,
+                }
+            )
+            results["deleted"] += 1
+
+            # 実行モードの場合、DataFrameから削除
+            if not dry_run:
+                original_idx = df[df["episode_id"] == ep_id].index[0]
+                df.drop(original_idx, inplace=True)
+        else:
+            # 三人称エピソードは修正
+            new_text = f"{prefix}{person_name}は{rest}"
+
+            change_record = {
+                "episode_id": ep_id,
+                "person_name": person_name,
+                "age": age,
+                "before": episode_text[:100] + "..." if len(episode_text) > 100 else episode_text,
+                "after": new_text[:100] + "..." if len(new_text) > 100 else new_text,
+            }
+            results["changes"].append(change_record)
+            results["fixed"] += 1
+
+            # 実行モードの場合、DataFrameを更新
+            if not dry_run:
+                original_idx = df[df["episode_id"] == ep_id].index[0]
+                df.at[original_idx, "episode_text"] = new_text
+
+    return results
+
+
+def print_b1_summary(results: Dict[str, Any]):
+    """B1修正結果のサマリーを表示"""
+    print("\n" + "=" * 80)
+    print("📊 B1違反修正 処理結果サマリー")
+    print("=" * 80)
+    print(f"対象エピソード数: {results['total']:,}件")
+    print(f"テキスト修正: {results['fixed']:,}件")
+    print(f"削除（一人称）: {results['deleted']:,}件")
+    print(f"スキップ（既に修正済み）: {results['skipped']:,}件")
+    print(f"未検出: {results['not_found']:,}件")
+
+    if results["changes"]:
+        print("\n【テキスト修正内容（先頭10件）】")
+        for i, change in enumerate(results["changes"][:10], 1):
+            print(f"\n{i}. {change['person_name']} (EP: {change['episode_id']})")
+            print(f"   Before: {change['before']}")
+            print(f"   After:  {change['after']}")
+        if len(results["changes"]) > 10:
+            print(f"\n... 他 {len(results['changes']) - 10}件")
+
+    if results["deletions"]:
+        print("\n【削除対象（一人称エピソード）】")
+        for i, deletion in enumerate(results["deletions"], 1):
+            print(f"\n{i}. {deletion['person_name']} (EP: {deletion['episode_id']})")
+            print(f"   理由: {deletion['reason']}")
+            print(f"   テキスト: {deletion['text_preview']}")
+
+    print("=" * 80)
+
+
 def print_summary(results: Dict[str, Any]):
     """処理結果のサマリーを表示"""
     print("\n" + "=" * 80)
@@ -188,10 +428,13 @@ def main():
         epilog="""
 Examples:
   # ドライラン（変更内容の確認のみ）
-  python scripts/fix_person_name_mismatch.py
+  python scripts/fix/fix_person_name_mismatch.py
 
   # 本番実行
-  python scripts/fix_person_name_mismatch.py --execute
+  python scripts/fix/fix_person_name_mismatch.py --execute
+
+  # B1違反のみ修正
+  python scripts/fix/fix_person_name_mismatch.py --b1-only --execute
         """,
     )
     parser.add_argument(
@@ -199,11 +442,19 @@ Examples:
         action="store_true",
         help="実際に変更を適用（デフォルト: ドライラン）",
     )
+    parser.add_argument(
+        "--b1-only",
+        action="store_true",
+        help="B1違反（テキストに人物名がない）のみ修正",
+    )
 
     args = parser.parse_args()
 
     print("=" * 80)
-    print("📝 リード文の人物名不一致修正スクリプト")
+    if args.b1_only:
+        print("📝 B1違反（テキストに人物名がない）修正スクリプト")
+    else:
+        print("📝 リード文の人物名不一致修正スクリプト")
     print("=" * 80)
     print(f"モード: {'実行' if args.execute else 'ドライラン（プレビュー）'}")
     print()
@@ -213,7 +464,7 @@ Examples:
         print(f"❌ エラー: マスターCSVが見つかりません: {MASTER_CSV_PATH}")
         return
 
-    df = pd.read_csv(MASTER_CSV_PATH, encoding="utf-8-sig")
+    df = pd.read_csv(MASTER_CSV_PATH, encoding="utf-8-sig", low_memory=False)
     print(f"✅ マスターCSV読み込み完了: {len(df)}件")
 
     # バックアップ作成（実行モードの場合のみ）
@@ -222,13 +473,19 @@ Examples:
 
     # 処理実行
     print("\n🔄 処理中...")
-    results = find_and_fix_mismatches(df, dry_run=not args.execute)
 
-    # サマリー表示
-    print_summary(results)
+    if args.b1_only:
+        # B1違反のみ修正
+        results = fix_b1_violations(df, dry_run=not args.execute)
+        print_b1_summary(results)
+    else:
+        # CORRECTION_MAPベースの修正
+        results = find_and_fix_mismatches(df, dry_run=not args.execute)
+        print_summary(results)
 
     # 実行モードの場合、CSVを保存
-    if args.execute:
+    total_changes = results["fixed"] + results.get("deleted", 0)
+    if args.execute and total_changes > 0:
         print("\n💾 マスターCSVを更新中...")
         df.to_csv(MASTER_CSV_PATH, index=False, encoding="utf-8-sig")
         print(f"✅ 更新完了: {MASTER_CSV_PATH}")
@@ -237,12 +494,22 @@ Examples:
     print("\n" + "=" * 80)
     if args.execute:
         print("✅ 処理完了: 変更を適用しました")
-        print(f"   修正件数: {results['fixed']:,}件")
+        if args.b1_only:
+            print(f"   テキスト修正: {results['fixed']:,}件")
+            print(f"   削除: {results.get('deleted', 0):,}件")
+        else:
+            print(f"   修正件数: {results['fixed']:,}件")
     else:
         print("💡 ドライランモード: 実際の変更は行われていません")
-        print(f"   修正対象: {results['fixed']:,}件")
-        print("\n   本番実行するには --execute オプションを追加してください：")
-        print("   python scripts/fix_person_name_mismatch.py --execute")
+        if args.b1_only:
+            print(f"   テキスト修正対象: {results['fixed']:,}件")
+            print(f"   削除対象: {results.get('deleted', 0):,}件")
+            print("\n   本番実行するには --execute オプションを追加してください：")
+            print("   python scripts/fix/fix_person_name_mismatch.py --b1-only --execute")
+        else:
+            print(f"   修正対象: {results['fixed']:,}件")
+            print("\n   本番実行するには --execute オプションを追加してください：")
+            print("   python scripts/fix/fix_person_name_mismatch.py --execute")
     print("=" * 80)
 
 

--- a/scripts/fix/fix_text_age_mismatch.py
+++ b/scripts/fix/fix_text_age_mismatch.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""
+本文の年齢表記修正スクリプト
+
+C1違反（age field vs text age mismatch）を修正する。
+Phase 18でageフィールドは text_year - birth_year で正しく修正済み。
+本文の「あなたと同じX歳のとき」をageフィールドに合わせて修正。
+
+Usage:
+    python scripts/fix/fix_text_age_mismatch.py --dry-run
+    python scripts/fix/fix_text_age_mismatch.py --execute
+"""
+
+import re
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+MASTER_CSV = PROJECT_ROOT / "preserved" / "data" / "MASTER_EPISODES_CURRENT.csv"
+BACKUP_DIR = PROJECT_ROOT / "preserved" / "backups"
+
+
+def create_backup(csv_path: Path, operation: str) -> Path:
+    """バックアップを作成"""
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_name = f"MASTER_EPISODES_{operation}_{timestamp}.csv"
+    backup_path = BACKUP_DIR / backup_name
+    shutil.copy2(csv_path, backup_path)
+    return backup_path
+
+
+def extract_text_age(episode_text: str) -> int | None:
+    """
+    本文から「同じX歳」パターンを抽出して年齢を返す
+
+    パターン:
+    - 「あなたと同じX歳のとき」
+    - 「同じX歳のとき」
+    """
+    if not episode_text or pd.isna(episode_text):
+        return None
+
+    # パターン: 「あなたと同じX歳のとき」または「同じX歳のとき」
+    pattern = r"(?:あなたと)?同じ(\d+)歳のとき"
+    match = re.search(pattern, str(episode_text))
+
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def replace_text_age(episode_text: str, correct_age: int) -> str:
+    """
+    本文の「同じX歳のとき」を正しい年齢に置換
+
+    Args:
+        episode_text: 元の本文
+        correct_age: 正しい年齢（ageフィールドの値）
+
+    Returns:
+        置換後の本文
+    """
+    if not episode_text or pd.isna(episode_text):
+        return episode_text
+
+    # パターン: 「あなたと同じX歳のとき」または「同じX歳のとき」
+    pattern = r"((?:あなたと)?同じ)\d+(歳のとき)"
+
+    def replacer(match):
+        return f"{match.group(1)}{correct_age}{match.group(2)}"
+
+    return re.sub(pattern, replacer, str(episode_text))
+
+
+def fix_text_age_mismatch(dry_run: bool = True) -> dict:
+    """
+    本文の年齢表記をageフィールドに合わせて修正
+
+    Args:
+        dry_run: Trueの場合、実際には保存しない（プレビューのみ）
+
+    Returns:
+        修正結果の統計情報
+    """
+    print("=" * 70)
+    print("C1違反修正: 本文の年齢表記をageフィールドに合わせる")
+    print("=" * 70)
+
+    # CSV読み込み
+    print(f"\n📂 CSV読み込み中: {MASTER_CSV}")
+    df = pd.read_csv(MASTER_CSV, dtype={"episode_id": str}, low_memory=False)
+    print(f"   総レコード数: {len(df):,}")
+
+    # 不整合を検出・修正
+    fixes = []
+    suspicious = []  # 差分が大きく疑わしいケース
+    skipped_no_pattern = 0
+    skipped_no_age = 0
+    skipped_invalid_age = 0
+    matched_ok = 0
+
+    # 差分閾値: これを超えると疑わしいケースとして別扱い
+    SUSPICIOUS_DIFF_THRESHOLD = 40
+
+    for idx, row in df.iterrows():
+        episode_id = row["episode_id"]
+        age_field = row.get("age")
+        episode_text = row.get("episode_text", "")
+
+        # 本文から年齢を抽出
+        text_age = extract_text_age(episode_text)
+
+        if text_age is None:
+            skipped_no_pattern += 1
+            continue
+
+        if age_field is None or (isinstance(age_field, float) and pd.isna(age_field)):
+            skipped_no_age += 1
+            continue
+
+        age_field_int = int(float(age_field))
+
+        # 異常なageフィールド値をスキップ（0未満または100超）
+        # Phase 18でbirth_yearが誤っている場合、異常なageになっている
+        # 100歳超は現実的でないためスキップ
+        if age_field_int < 0 or age_field_int > 100:
+            skipped_invalid_age += 1
+            continue
+
+        if text_age == age_field_int:
+            matched_ok += 1
+            continue
+
+        diff = age_field_int - text_age
+
+        # 差分が大きすぎる場合は疑わしいケースとして別扱い
+        # birth_yearが誤っている可能性が高い
+        if abs(diff) > SUSPICIOUS_DIFF_THRESHOLD:
+            suspicious.append(
+                {
+                    "episode_id": episode_id,
+                    "person_name": row.get("person_name", ""),
+                    "text_age": text_age,
+                    "age_field": age_field_int,
+                    "diff": diff,
+                    "birth_year": row.get("birth_year"),
+                    "idx": idx,
+                }
+            )
+            continue
+
+        # 不整合: 本文を修正
+        new_text = replace_text_age(episode_text, age_field_int)
+
+        fixes.append(
+            {
+                "episode_id": episode_id,
+                "person_name": row.get("person_name", ""),
+                "text_age": text_age,
+                "correct_age": age_field_int,
+                "diff": diff,
+                "old_text_snippet": str(episode_text)[:60] if episode_text else "",
+                "new_text": new_text,
+                "idx": idx,
+            }
+        )
+
+    # 結果表示
+    print("\n📊 検出結果:")
+    print(f"   パターンなしでスキップ: {skipped_no_pattern:,}")
+    print(f"   ageフィールドなしでスキップ: {skipped_no_age:,}")
+    print(f"   異常age(0未満or100超)スキップ: {skipped_invalid_age:,}")
+    print(f"   整合OK（修正不要）: {matched_ok:,}")
+    print(f"   疑わしいケース（差分>{SUSPICIOUS_DIFF_THRESHOLD}）: {len(suspicious)}")
+    print(f"   不整合件数（要修正）: {len(fixes)}")
+
+    if fixes:
+        print("\n📋 修正対象一覧:")
+        print("-" * 100)
+        print(f"   {'No':>3s}  {'episode_id':20s}  {'person_name':20s}  " f"{'text':>4s} → {'age':>4s}  {'diff':>5s}")
+        print("-" * 100)
+        for i, fix in enumerate(fixes[:50], 1):  # 最大50件表示
+            person_name = fix["person_name"][:18] if fix["person_name"] else ""
+            print(
+                f"   {i:3d}. {fix['episode_id']:20s}  {person_name:20s}  "
+                f"{fix['text_age']:4d} → {fix['correct_age']:4d}  ({fix['diff']:+4d})"
+            )
+        if len(fixes) > 50:
+            print(f"   ... 他 {len(fixes) - 50} 件")
+        print("-" * 100)
+
+    # 疑わしいケースの警告表示
+    if suspicious:
+        print(f"\n⚠️ 疑わしいケース（差分>{SUSPICIOUS_DIFF_THRESHOLD}、修正対象外）:")
+        print("-" * 110)
+        print(
+            f"   {'No':>3s}  {'episode_id':20s}  {'person_name':20s}  "
+            f"{'text':>4s}  {'age':>4s}  {'diff':>5s}  {'birth_year':>10s}"
+        )
+        print("-" * 110)
+        for i, s in enumerate(suspicious[:20], 1):  # 最大20件表示
+            person_name = s["person_name"][:18] if s["person_name"] else ""
+            birth = int(s["birth_year"]) if pd.notna(s["birth_year"]) else "?"
+            print(
+                f"   {i:3d}. {s['episode_id']:20s}  {person_name:20s}  "
+                f"{s['text_age']:4d}  {s['age_field']:4d}  ({s['diff']:+4d})  {birth:>10}"
+            )
+        if len(suspicious) > 20:
+            print(f"   ... 他 {len(suspicious) - 20} 件")
+        print("-" * 110)
+        print("   ※ これらはbirth_yearが誤っている可能性があります。手動確認を推奨。")
+
+    # 修正実行
+    if not dry_run and fixes:
+        print("\n🔧 修正実行中...")
+
+        # バックアップ作成
+        backup_path = create_backup(MASTER_CSV, "text_age_mismatch")
+        print(f"   バックアップ作成: {backup_path.name}")
+
+        # 修正適用: 本文を更新
+        for fix in fixes:
+            df.at[fix["idx"], "episode_text"] = fix["new_text"]
+
+        # 保存
+        df.to_csv(MASTER_CSV, index=False)
+        print(f"   ✅ CSV保存完了: {MASTER_CSV}")
+    elif dry_run:
+        print("\n⚠️ ドライラン: 実際の修正は行いません")
+        print("   実行するには --execute オプションを付けてください")
+
+    return {
+        "total_records": len(df),
+        "skipped_no_pattern": skipped_no_pattern,
+        "skipped_no_age": skipped_no_age,
+        "skipped_invalid_age": skipped_invalid_age,
+        "matched_ok": matched_ok,
+        "suspicious_count": len(suspicious),
+        "fixes_count": len(fixes),
+        "fixes": fixes,
+        "suspicious": suspicious,
+    }
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="C1違反修正: 本文の年齢表記をageフィールドに合わせる")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="実際に修正を実行する（デフォルトはドライラン）",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="変更をプレビュー（デフォルト）",
+    )
+
+    args = parser.parse_args()
+
+    # --execute が指定された場合は dry_run を False に
+    dry_run = not args.execute
+
+    result = fix_text_age_mismatch(dry_run=dry_run)
+
+    print("\n📈 サマリー:")
+    print(f"   総レコード数: {result['total_records']:,}")
+    print(f"   パターンなしスキップ: {result['skipped_no_pattern']:,}")
+    print(f"   ageなしスキップ: {result['skipped_no_age']:,}")
+    print(f"   異常ageスキップ: {result['skipped_invalid_age']:,}")
+    print(f"   整合OK: {result['matched_ok']:,}")
+    print(f"   疑わしいケース: {result['suspicious_count']}")
+    print(f"   修正件数: {result['fixes_count']}")
+
+    if args.execute and result["fixes_count"] > 0:
+        print("\n✅ 修正完了!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix/remove_future_event_episodes.py
+++ b/scripts/fix/remove_future_event_episodes.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+未来年号エピソード削除スクリプト
+
+C2違反（2027年以降の年号を含むエピソード）を削除する。
+episode_textに2027年以降の年号が含まれるエピソードは、
+架空の未来イベント（「2029年の東京国際映画祭で受賞」など）であり、
+事実違反となる。
+
+処理ロジック:
+1. CSVを読み込む
+2. 各行について:
+   - episode_textから年号パターンを検索: (202[7-9]|20[3-9]\d|21\d{2})年
+   - マッチした場合、そのエピソードを削除対象としてマーク
+3. 削除対象以外のエピソードのみを保存
+
+Usage:
+    # ドライラン（確認のみ）
+    python scripts/fix/remove_future_event_episodes.py --dry-run
+
+    # 実行（実際に削除）
+    python scripts/fix/remove_future_event_episodes.py --execute
+
+    # 詳細出力
+    python scripts/fix/remove_future_event_episodes.py --execute --verbose
+
+Author: EPUP Fix Team
+Date: 2026-02-02
+RCA: C2違反 - 未来年号エピソード
+"""
+
+import argparse
+import re
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+# プロジェクトルート
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+MASTER_CSV = PROJECT_ROOT / "preserved/data/MASTER_EPISODES_CURRENT.csv"
+BACKUP_DIR = PROJECT_ROOT / "preserved/data/backups"
+LOG_DIR = PROJECT_ROOT / "src/reports/logs"
+
+# 2027年以降を検出するパターン
+# 202[7-9]年、203X年、204X年...209X年、21XX年
+FUTURE_YEAR_PATTERN = re.compile(r"(202[7-9]|20[3-9]\d|21\d{2})年")
+
+
+def detect_future_years(text: str) -> list[str]:
+    """
+    テキストから未来年号を検出する
+
+    Args:
+        text: エピソードテキスト
+
+    Returns:
+        検出された未来年号のリスト
+    """
+    if pd.isna(text) or not isinstance(text, str):
+        return []
+
+    matches = FUTURE_YEAR_PATTERN.findall(text)
+    return [f"{m}年" for m in matches]
+
+
+def create_backup(csv_path: Path) -> Path:
+    """
+    CSVファイルのバックアップを作成
+
+    Args:
+        csv_path: バックアップ元のCSVパス
+
+    Returns:
+        バックアップファイルのパス
+    """
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_filename = f"MASTER_EPISODES_{timestamp}_pre_future_fix.csv"
+    backup_path = BACKUP_DIR / backup_filename
+
+    shutil.copy2(csv_path, backup_path)
+
+    return backup_path
+
+
+def write_deletion_log(
+    deleted_records: list[dict],
+    log_dir: Path,
+) -> Path:
+    """
+    削除したエピソードをログファイルに記録
+
+    Args:
+        deleted_records: 削除したエピソードの詳細リスト
+        log_dir: ログ出力ディレクトリ
+
+    Returns:
+        ログファイルのパス
+    """
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_filename = f"deleted_future_events_{timestamp}.log"
+    log_path = log_dir / log_filename
+
+    with open(log_path, "w", encoding="utf-8") as f:
+        f.write("# 未来年号エピソード削除ログ\n")
+        f.write(f"# 実行日時: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+        f.write(f"# 削除件数: {len(deleted_records)}\n")
+        f.write("# RCA: C2違反 - 未来年号エピソード\n")
+        f.write("#\n")
+        f.write("# 削除したエピソード一覧:\n")
+        f.write("# episode_id | person_name | 検出された年号\n")
+        f.write("#\n")
+        for rec in deleted_records:
+            f.write(f"{rec['episode_id']} | {rec['person_name']} | {rec['years']}\n")
+
+    return log_path
+
+
+def main():
+    """メイン処理"""
+    parser = argparse.ArgumentParser(description="C2違反: 未来年号エピソード削除スクリプト")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="ドライラン（確認のみ）",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="実際に削除を実行",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="詳細出力",
+    )
+    parser.add_argument(
+        "--show-samples",
+        type=int,
+        default=20,
+        help="サンプル表示件数（デフォルト: 20）",
+    )
+
+    args = parser.parse_args()
+
+    # --executeも--dry-runも指定されていない場合はdry-run
+    if not args.execute and not args.dry_run:
+        args.dry_run = True
+
+    is_dry_run = args.dry_run or not args.execute
+
+    # ヘッダー
+    print("=" * 70)
+    print("C2違反: 未来年号エピソード削除スクリプト")
+    print(f"実行日時: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"モード: {'ドライラン（確認のみ）' if is_dry_run else '実行モード'}")
+    print("=" * 70)
+
+    # マスターCSV存在確認
+    if not MASTER_CSV.exists():
+        print(f"\n[ERROR] マスターCSVが見つかりません: {MASTER_CSV}")
+        return 2
+
+    # マスターCSV読み込み
+    print(f"\nマスターCSV: {MASTER_CSV}")
+    df = pd.read_csv(MASTER_CSV, encoding="utf-8-sig", low_memory=False)
+    print(f"現在のエピソード数: {len(df):,}件")
+
+    # episode_textから未来年号を検出
+    print("\n未来年号（2027年以降）を検出中...")
+
+    deleted_records = []
+    delete_indices = []
+
+    for idx, row in df.iterrows():
+        episode_text = row.get("episode_text", "")
+        future_years = detect_future_years(episode_text)
+
+        if future_years:
+            delete_indices.append(idx)
+            deleted_records.append(
+                {
+                    "episode_id": row.get("episode_id", "N/A"),
+                    "person_name": row.get("person_name", "N/A"),
+                    "years": ", ".join(future_years),
+                    "text_preview": str(episode_text)[:100] if episode_text else "",
+                }
+            )
+
+    print("\n検出結果:")
+    print(f"  削除対象: {len(deleted_records):,}件")
+
+    if not deleted_records:
+        print("\n[INFO] 未来年号を含むエピソードはありませんでした。")
+        return 0
+
+    # 年号別の集計
+    year_counts = {}
+    for rec in deleted_records:
+        for y in rec["years"].split(", "):
+            year_counts[y] = year_counts.get(y, 0) + 1
+
+    print("\n年号別件数（上位10件）:")
+    for year, count in sorted(year_counts.items(), key=lambda x: -x[1])[:10]:
+        print(f"  {year}: {count:,}件")
+
+    # サンプル表示
+    if args.verbose or is_dry_run:
+        print(f"\n{'=' * 70}")
+        print(f"削除対象エピソード（{min(args.show_samples, len(deleted_records))}件）")
+        print("=" * 70)
+
+        for i, rec in enumerate(deleted_records[: args.show_samples], 1):
+            print(f"\n{i}. {rec['episode_id']}")
+            print(f"   人物名: {rec['person_name']}")
+            print(f"   検出年号: {rec['years']}")
+            print(f"   テキスト: {rec['text_preview']}...")
+
+        if len(deleted_records) > args.show_samples:
+            print(f"\n   ... 他 {len(deleted_records) - args.show_samples:,}件")
+
+    # ドライランの場合はここで終了
+    if is_dry_run:
+        print(f"\n{'=' * 70}")
+        print("[DRY RUN] 確認のみ - 実際の削除は行われていません")
+        print("=" * 70)
+        print(f"\n[INFO] 削除対象: {len(deleted_records):,}件")
+        print("\n削除を実行するには --execute オプションを付けて再実行してください:")
+        print("  python scripts/fix/remove_future_event_episodes.py --execute")
+        print(f"{'=' * 70}")
+        return 0
+
+    # 実行モード: バックアップ作成
+    print(f"\n{'=' * 70}")
+    print("削除実行")
+    print("=" * 70)
+
+    print("\n1. バックアップを作成中...")
+    backup_path = create_backup(MASTER_CSV)
+    print(f"   [INFO] バックアップ作成: {backup_path}")
+
+    # CSVから削除
+    print("\n2. CSVから該当エピソードを削除中...")
+    original_count = len(df)
+
+    # 削除対象以外を残す
+    df_filtered = df.drop(delete_indices)
+    deleted_count = original_count - len(df_filtered)
+
+    print(f"   削除前: {original_count:,}件")
+    print(f"   削除後: {len(df_filtered):,}件")
+    print(f"   [INFO] 削除完了: {deleted_count:,}件")
+
+    # CSVを上書き保存
+    print("\n3. CSVを保存中...")
+    df_filtered.to_csv(MASTER_CSV, index=False, encoding="utf-8-sig")
+    print(f"   保存完了: {MASTER_CSV}")
+
+    # 削除ログ出力
+    print("\n4. 削除ログを出力中...")
+    log_path = write_deletion_log(deleted_records, LOG_DIR)
+    print(f"   ログ: {log_path}")
+
+    # 完了
+    print(f"\n{'=' * 70}")
+    print("[SUCCESS] 削除完了")
+    print("=" * 70)
+    print(f"削除件数: {deleted_count:,}件")
+    print(f"残存エピソード: {len(df_filtered):,}件")
+    print(f"バックアップ: {backup_path}")
+    print(f"ログファイル: {log_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- B1違反（名前不一致）修正: 97件（テキスト修正90件 + 削除7件）
- C1違反（本文年齢不整合）修正: 2,133件
- C2違反（未来年号エピソード）削除: 5,172件

## 結果

| 指標 | 修正前 | 修正後 |
|------|--------|--------|
| 総エピソード数 | 59,875 | 54,696 |
| 違反合計 | 8,593 | 1,092 |

## Test plan
- [x] detect_all_inconsistencies.py で違反件数確認
- [x] ダッシュボード正常表示確認
- [x] pre-commit hooks 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**新機能**
* エピソードの人物名不一致を修正する新しい修復機能を追加
* エピソードテキスト内の年齢の矛盾を検出・修正する機能を追加
* 将来のイベント日付を含むエピソードを自動削除する機能を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->