### PR TITLE
feat(dashboard): ハイブリッドスコア表示を追加

### DIFF
--- a/preserved/episode_database_dashboard_v11.html
+++ b/preserved/episode_database_dashboard_v11.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f51aee7cb681876ba98edd89e0f5d7ce66ec063e20231f7b489d50d8d5ca2fbd
-size 388041
+oid sha256:07c5c85b5394fd2dbb07cce04cac8469dafb25aa4b044379e910549c1f30fcc2
+size 389370

--- a/scripts/update_dashboard_v10.py
+++ b/scripts/update_dashboard_v10.py
@@ -131,6 +131,8 @@ def load_csv_data():
                 "textbook": str(row.get("textbook", "False")).lower() == "true",
                 # desirability関連スコア
                 "desirability_score": float(row.get("desirability_score", 0) or 0),
+                # ハイブリッドスコア（Hybrid-C）
+                "hybrid_score": float(row.get("hybrid_score", 0) or 0),
                 "event_magnitude": float(row.get("event_magnitude", 0) or 0),
                 "recency_boost": float(row.get("recency_boost", 0) or 0),
             }


### PR DESCRIPTION
## Summary
- ダッシュボードのエピソードカードに「ハイブリッド」スコアを表示
- ソート機能対応（クリックでhybrid_score順にソート可能）

## 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `preserved/episode_database_dashboard_v11.html` | ハイブリッドスコア表示・ソート追加 |
| `scripts/update_dashboard_v10.py` | hybrid_scoreカラム読み込み追加 |

## スクリーンショット
メインスコア行に「ハイブリッド」が追加されます：
- 超総合 → 有名人度 → エピ有名度 → 読みたさ → **ハイブリッド**

## Test plan
- [x] ダッシュボード再生成
- [x] ハイブリッドスコア表示確認
- [ ] ソート機能動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エピソードデータに新しいハイブリッドスコア指標を追加しました。

* **その他の更新**
  * ダッシュボードのデータファイルを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->