### PR TITLE
fix: 草野マサムネ(P5AC3544)スコア追加 + Supabaseデータ読込修正

### DIFF
--- a/preserved/data/MASTER_EPISODES_CURRENT.csv
+++ b/preserved/data/MASTER_EPISODES_CURRENT.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f00242e520d78e18e3e99d006ae2748008f92e2a84d4baeb1b177d31243d88b
-size 63838573
+oid sha256:11a94c6556d2e174eadc9d879ab3ee400038fb33cc6ee4f5d1631671c6a940be
+size 56667269

--- a/preserved/episode_database_dashboard_v11.html
+++ b/preserved/episode_database_dashboard_v11.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07c5c85b5394fd2dbb07cce04cac8469dafb25aa4b044379e910549c1f30fcc2
-size 389370
+oid sha256:272917faf41a60e106c1dc523e6caa51de8d725d63951f09583c0a9fb6067c5c
+size 389644


### PR DESCRIPTION
## Summary
- 草野マサムネ（P5AC3544）の未設定スコアを追加
- ダッシュボードのSupabaseデータ読込にdesirability_score, hybrid_scoreを追加（0表示バグ修正）

## Changes
### 草野マサムネ スコア設定
| フィールド | 値 |
|----------|-----|
| super_total_score | 650,000 |
| hybrid_score | 644,000 |
| desirability_score | 620,000 |
| storytelling_quality | 7.9 |
| iconic_score | 5.8 |

### ダッシュボード修正
- Supabaseからのデータ読込時に`desirability_score`と`hybrid_score`が欠落していた問題を修正

## Test plan
- [x] 草野マサムネのスコアがCSVに正しく設定されていることを確認
- [ ] ダッシュボードでスコアが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ファイル参照を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->