### PR TITLE
ci(ios): Xcode Cloud で SwiftLint をインストールして警告を解消

### DIFF
--- a/ios-apps/final-hourglass/ci_scripts/ci_post_clone.sh
+++ b/ios-apps/final-hourglass/ci_scripts/ci_post_clone.sh
@@ -5,6 +5,17 @@ echo "=== Xcode Cloud: Build Environment ==="
 echo "CI_PRIMARY_REPOSITORY_PATH: $CI_PRIMARY_REPOSITORY_PATH"
 echo "CI_WORKSPACE: $CI_WORKSPACE"
 
+# SwiftLint インストール（Xcode Cloud 環境用）
+echo "=== Installing SwiftLint ==="
+if which brew >/dev/null; then
+    brew install swiftlint 2>/dev/null || echo "✅ SwiftLint already installed or skipped"
+    if which swiftlint >/dev/null; then
+        echo "✅ SwiftLint version: $(swiftlint version)"
+    fi
+else
+    echo "⚠️ Homebrew not available, skipping SwiftLint installation"
+fi
+
 echo "=== Verifying workspace exists ==="
 WORKSPACE_PATH="$CI_PRIMARY_REPOSITORY_PATH/ios-apps/final-hourglass/FinalHourglass.xcworkspace"
 if [ -d "$WORKSPACE_PATH" ]; then


### PR DESCRIPTION
## Summary
- Xcode Cloud の ci_post_clone.sh に SwiftLint インストール処理を追加
- これにより「warning: SwiftLint not installed」警告が解消される

## Changes
- `ci_post_clone.sh`: Homebrew 経由で SwiftLint をインストール
- インストール成功時にバージョンを表示して確認

## Test plan
- [ ] Xcode Cloud でビルドが成功する
- [ ] SwiftLint 警告が表示されない（⚠️ 0件）
- [ ] ビルドログに「Installing SwiftLint」メッセージが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDビルドプロセスにSwiftLintの自動インストール機能を追加しました。Homebrewが利用可能な環境では自動的にインストールされ、利用できない環境では警告を表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->