### PR TITLE
fix(ios): SwiftLint 設定ファイルパスを修正して lint エラーを解消

### DIFF
--- a/ios-apps/final-hourglass/FinalHourglass.xcodeproj/project.pbxproj
+++ b/ios-apps/final-hourglass/FinalHourglass.xcodeproj/project.pbxproj
@@ -453,7 +453,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# SwiftLint Build Phase Script\n# Auto-fix and lint Swift files on build\n\nif which swiftlint >/dev/null; then\n  # Run SwiftLint with autocorrect first, then lint\n  swiftlint lint --fix && swiftlint lint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "# SwiftLint Build Phase Script\n# Auto-fix and lint Swift files on build\n\nif which swiftlint >/dev/null; then\n  # Change to project root to ensure .swiftlint.yml is found\n  cd \"$SRCROOT\"\n  # Run SwiftLint with autocorrect first, then lint (explicitly specify config)\n  swiftlint lint --fix --config .swiftlint.yml && swiftlint lint --config .swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Summary
- Xcode Cloud で SwiftLint 実行時に `.swiftlint.yml` 設定ファイルが読み込まれない問題を修正
- Build Phase スクリプトに `cd "$SRCROOT"` と `--config .swiftlint.yml` オプションを追加

## 修正内容

### 問題
PR #86 で SwiftLint をインストールしたが、Xcode Cloud 環境で以下のエラーが発生:
- `type_body_length` エラー 3件（SettingsView, AboutView, LifeResultView）
- `identifier_name` エラー 3件（`_body`, `i` 変数）
- 約100件の警告

### 原因
SwiftLint が `.swiftlint.yml` を見つけられず、デフォルト設定で実行されていた。

### 解決策
Build Phase スクリプトを修正:
```bash
# Before
swiftlint lint --fix && swiftlint lint

# After
cd "$SRCROOT"
swiftlint lint --fix --config .swiftlint.yml && swiftlint lint --config .swiftlint.yml
```

## Test plan
- [x] ローカルで `swiftlint lint --config .swiftlint.yml` を実行 → **0 violations, 0 serious**
- [ ] Xcode Cloud でビルド成功を確認
- [ ] SwiftLint エラーが 0 件であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)