### PR TITLE
fix(ios): .swiftlint.yml をGit追跡に追加してXcode Cloudビルドを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,6 +342,7 @@ ios-apps/final-hourglass/*
 !ios-apps/final-hourglass/ci_scripts/
 !ios-apps/final-hourglass/Config/
 !ios-apps/final-hourglass/Documentation/
+!ios-apps/final-hourglass/.swiftlint.yml
 .crash-guard/
 output/name_application/preview_applied.csv
 

--- a/ios-apps/final-hourglass/.swiftlint.yml
+++ b/ios-apps/final-hourglass/.swiftlint.yml
@@ -1,0 +1,75 @@
+# SwiftLint Configuration for FinalHourglass
+# Version: 0.63.1+
+
+included:
+- FinalHourglass
+
+excluded:
+- Pods
+- .build
+- DerivedData
+- FinalHourglassTests
+- FinalHourglassUITests
+- '**/Backups/**'    # バックアップファイルを除外
+- '**/*_backup.swift'
+- '**/*_buckup.swift'
+
+# 有効ルール（段階的に厳しく）
+opt_in_rules:
+- closure_spacing
+- empty_count
+- explicit_init
+- sorted_imports
+- vertical_whitespace_closing_braces
+- vertical_whitespace_opening_braces
+
+# 無効ルール（ノイズ削減）
+disabled_rules:
+- trailing_whitespace
+- multiple_closures_with_trailing_closure    # SwiftUI Button等で頻出
+
+# カスタム設定
+line_length:
+  warning: 150
+  error: 200
+  ignores_comments: true
+  ignores_urls: true
+
+file_length:
+  warning: 1000
+  error: 2500  # OnboardingView.swift (2142行) 等を許容
+
+type_body_length:
+  warning: 500
+  error: 1000  # 大規模Viewを許容
+
+function_body_length:
+  warning: 50
+  error: 150  # 複雑なView初期化等を許容
+
+# 識別子の長さ
+identifier_name:
+  min_length:
+    warning: 2
+    error: 1
+  max_length:
+    warning: 50
+    error: 60
+  excluded:
+  - id
+  - x
+  - y
+  - i
+  - j
+  - k
+  - _body    # TextFieldStyle等のプロトコル要件
+
+# ネスト深度
+nesting:
+  type_level:
+    warning: 3
+  function_level:
+    warning: 5
+
+# レポーター（CI用）
+reporter: xcode


### PR DESCRIPTION
## Summary
- .gitignore に `!ios-apps/final-hourglass/.swiftlint.yml` を追加
- .swiftlint.yml をリポジトリに追加

## 問題
Xcode Cloud ビルド17で以下のエラーが発生:
```
Could not read file at path '/Volumes/workspace/repository/ios-apps/final-hourglass/.swiftlint.yml'
```

## 原因
`.swiftlint.yml` がローカルには存在するが、`.gitignore` の `ios-apps/final-hourglass/*` パターンで除外されていた。

## Test plan
- [ ] GitHub Actions CI パス
- [ ] Xcode Cloud ビルド18 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チア（Chores）**
  * FinalHourglassプロジェクトのコード品質標準を維持するため、SwiftLint設定ファイルを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->