### PR TITLE
fix(ci): GitHub Actions iOSワークフロー修正 (#82)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
           # SwiftLint の最新版をダウンロード
           SWIFTLINT_VERSION="0.58.0"
           curl -sL "https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/swiftlint_linux.zip" -o swiftlint.zip
-          unzip -q swiftlint.zip
+          unzip -o -q swiftlint.zip -x LICENSE
           sudo mv swiftlint /usr/local/bin/
           swiftlint version
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run OWASP Dependency-Check
         uses: dependency-check/Dependency-Check_Action@main
         with:
-          project: "claude-code-template-mcp"
+          project: "final-hourglass"
           path: "."
           format: "ALL"
           args: >


### PR DESCRIPTION
## Summary
- SwiftLint の unzip 上書き問題を修正（`-o -x LICENSE` オプション追加）
- security-scan.yml のプロジェクト名を正しい名前に更新

## 変更内容

### 1. lint.yml（必須修正）
```diff
- unzip -q swiftlint.zip
+ unzip -o -q swiftlint.zip -x LICENSE
```
- `-o`: 確認なしで上書き（CI環境での対話回避）
- `-x LICENSE`: LICENSEファイルを除外（リポジトリのLICENSEとの衝突防止）

### 2. security-scan.yml（推奨修正）
```diff
- project: "claude-code-template-mcp"
+ project: "final-hourglass"
```

## Issue #82 記載問題のステータス

| Issue記載の問題 | ステータス |
|----------------|----------|
| SwiftLint: unzip上書き問題 | ✅ 今回修正 |
| cocoapods-audit gem問題 | ✅ 既に解決済み |
| iOS Build exit code 65 | ✅ 既に解決済み（Xcode Cloud移行） |
| build-metrics依存関係 | ✅ 既に解決済み |
| dependency-check iOS問題 | ✅ 今回修正（プロジェクト名のみ） |

## Test plan
- [ ] PR作成後、SwiftLintジョブが正常に完了することを確認
- [ ] security-scan.ymlはmainマージ後またはweekly scheduleで検証

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このリリースには、エンドユーザーに直接影響する変更は含まれていません。すべての変更は内部開発ツールの構成に関するものです。

**該当するカテゴリなし**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->