### PR TITLE
fix(ci): タグプッシュ時の重複チェックをスキップ

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -61,6 +61,7 @@ jobs:
           echo "🔢 Build number: $BUILD_NUMBER"
 
       - name: Check for Duplicate Tag
+        if: github.event_name == 'workflow_dispatch'
         run: |
           TAG="ios-v${{ steps.version.outputs.value }}"
           if git tag -l | grep -qx "$TAG"; then


### PR DESCRIPTION
## Summary
- iOSリリースワークフローのタグ重複チェックを修正
- `workflow_dispatch`時のみ重複チェックを実行
- タグプッシュトリガー時は既存タグが当然存在するためスキップ

## 背景
`ios-v1.0.1`タグプッシュ時にワークフローが失敗：
```
❌ Tag ios-v1.0.1 already exists
```

タグプッシュでトリガーされた場合、そのタグは既に存在しているため重複チェックは不要。

## Test plan
- [ ] 修正後のワークフローでタグプッシュが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOSリリースワークフローの条件判定を改善しました。「重複タグチェック」ステップがワークフロー手動実行時のみ実行されるよう調整されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->