### PR TITLE
fix(ci): correct ExportOptions.plist path and add certificate diagnostics

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -217,13 +217,34 @@ jobs:
           CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
           echo "$CERTIFICATE_BASE64" | base64 --decode > $CERTIFICATE_PATH
 
+          # 証明書ファイルの検証
+          echo "🔍 Verifying certificate file..."
+          if [ ! -s "$CERTIFICATE_PATH" ]; then
+            echo "❌ Certificate file is empty or not created"
+            exit 1
+          fi
+          echo "📄 Certificate file size: $(wc -c < $CERTIFICATE_PATH) bytes"
+
+          # 証明書情報の確認（パスワードなしで可能な範囲）
+          echo "🔍 Checking certificate contents..."
+          openssl pkcs12 -info -in "$CERTIFICATE_PATH" -passin "pass:$CERTIFICATE_PASSWORD" -nokeys 2>&1 | head -20 || {
+            echo "⚠️ Warning: Could not parse certificate with provided password"
+            echo "This may indicate incorrect password or corrupted certificate"
+          }
+
           security import $CERTIFICATE_PATH \
             -P "$CERTIFICATE_PASSWORD" \
             -f pkcs12 \
             -k $KEYCHAIN_PATH \
             -T /usr/bin/codesign \
-            -T /usr/bin/productsign || {
+            -T /usr/bin/productsign \
+            -A 2>&1 || {
               echo "❌ Certificate import failed"
+              echo "🔍 Attempting verbose import for debugging..."
+              security import $CERTIFICATE_PATH \
+                -P "$CERTIFICATE_PASSWORD" \
+                -k $KEYCHAIN_PATH \
+                -T /usr/bin/codesign 2>&1 || true
               rm -f $CERTIFICATE_PATH
               exit 1
             }
@@ -317,6 +338,7 @@ jobs:
           ARCHIVE_PATH=${{ steps.archive.outputs.path }}
           EXPORT_PATH=$RUNNER_TEMP/Export
           IPA_PATH="$EXPORT_PATH/FinalHourglass.ipa"
+          EXPORT_OPTIONS_PATH="${{ github.workspace }}/ios-apps/final-hourglass/ExportOptions.plist"
 
           if [ -z "${{ secrets.DISTRIBUTION_CERTIFICATE_BASE64 }}" ]; then
             echo "⚠️ Skipping IPA export (dry-run mode - no signing credentials)"
@@ -324,10 +346,18 @@ jobs:
             exit 0
           fi
 
+          # ExportOptions.plist存在確認
+          if [ ! -f "$EXPORT_OPTIONS_PATH" ]; then
+            echo "❌ ExportOptions.plist not found at: $EXPORT_OPTIONS_PATH"
+            ls -la "${{ github.workspace }}/ios-apps/final-hourglass/" || true
+            exit 1
+          fi
+          echo "📄 Using ExportOptions.plist: $EXPORT_OPTIONS_PATH"
+
           xcodebuild -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
             -exportPath "$EXPORT_PATH" \
-            -exportOptionsPlist ExportOptions.plist \
+            -exportOptionsPlist "$EXPORT_OPTIONS_PATH" \
             | xcpretty --color || {
               echo "❌ IPA export failed"
               exit 1


### PR DESCRIPTION
## Summary
- ExportOptions.plistの絶対パスを使用するよう修正
- 証明書ファイルサイズの検証を追加
- opensslによる証明書パース（デバッグ用）を追加
- security importに-Aフラグを追加
- インポート失敗時の詳細デバッグ出力を追加

## Test plan
- [ ] `ios-v1.0.5`タグをプッシュしてワークフローを実行
- [ ] 証明書インポートのログを確認
- [ ] ExportOptions.plistパスのログを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * iOS リリースビルドの信頼性向上：証明書インポート処理の検証チェックとエラーハンドリングを強化
  * ビルド設定の検証機能を追加：必要なファイルの存在確認とエラーメッセージの改善

* **改善**
  * ビルドワークフローの堅牢性向上：詳細なログ出力とフォールバック処理を実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->