### PR TITLE
ci: iOS Archive診断用にxcpretty除去とdestination追加

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -338,10 +338,11 @@ jobs:
               -workspace FinalHourglass.xcworkspace \
               -scheme FinalHourglass \
               -configuration Release \
+              -destination 'generic/platform=iOS' \
               -archivePath "$ARCHIVE_PATH" \
               MARKETING_VERSION="$VERSION" \
               CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
-              | xcpretty --color || {
+              || {
                 echo "❌ Archive failed"
                 exit 1
               }


### PR DESCRIPTION
## Summary
- Archive（本番署名）ステップからxcprettyを除去し、xcodebuildの生エラー出力を確認可能にした
- `-destination 'generic/platform=iOS'`を追加し、プラットフォーム選択の曖昧さを解消

## Background
dry_run=false（本番署名）でArchiveが失敗するが、xcprettyがエラー詳細をフィルタリングしていて原因特定ができなかった。

## Test plan
- [ ] このPRをマージ後、`gh workflow run ios-release.yml -f version=1.0.8 -f dry_run=false`でArchiveのエラー詳細を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS リリースワークフローの改善を実施しました。ビルドプロセスのエラーハンドリングが更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->