### PR TITLE
ci: iOS Archive署名設定をCI環境用に修正

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -297,8 +297,15 @@ jobs:
             exit 0
           fi
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo "$PROFILE_BASE64" | base64 --decode > ~/Library/MobileDevice/Provisioning\ Profiles/distribution.mobileprovision
-          echo "✅ Provisioning profile installed"
+          PROFILE_PATH=$RUNNER_TEMP/distribution.mobileprovision
+          echo "$PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+
+          # UUIDを取得してUUID名でインストール（Xcodeが認識するため）
+          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< $(security cms -D -i "$PROFILE_PATH"))
+          echo "📋 Profile UUID: $PROFILE_UUID"
+          cp "$PROFILE_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${PROFILE_UUID}.mobileprovision
+          rm -f "$PROFILE_PATH"
+          echo "✅ Provisioning profile installed (UUID: $PROFILE_UUID)"
 
       - name: Update Version Numbers
         env:
@@ -340,8 +347,12 @@ jobs:
               -configuration Release \
               -destination 'generic/platform=iOS' \
               -archivePath "$ARCHIVE_PATH" \
+              -allowProvisioningUpdates \
               MARKETING_VERSION="$VERSION" \
               CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+              CODE_SIGN_STYLE=Manual \
+              CODE_SIGN_IDENTITY="Apple Distribution" \
+              PROVISIONING_PROFILE_SPECIFIER="" \
               || {
                 echo "❌ Archive failed"
                 exit 1


### PR DESCRIPTION
## Summary
- Archive（本番署名）ステップの署名設定をCI環境に合わせて修正
- Provisioning ProfileをUUID名でインストールするよう改善

## Root Cause
Xcodeプロジェクトが `CODE_SIGN_STYLE=Automatic` + `CODE_SIGN_IDENTITY="Apple Development"` で設定されており、CI環境でDistribution証明書を使ったアーカイブ時に:
```
error: No profiles for 'com.AIUELAB.FinalHourglass' were found
```
が発生していた。

## Changes
1. **署名スタイル変更**: `CODE_SIGN_STYLE=Manual` + `CODE_SIGN_IDENTITY="Apple Distribution"` をxcodebuildコマンドでオーバーライド
2. **Provisioning Profile**: UUID名でインストール（Xcodeが自動認識するため）
3. **`-allowProvisioningUpdates`**: プロビジョニング更新を許可

## Test plan
- [ ] マージ後 `gh workflow run ios-release.yml -f version=1.0.8 -f dry_run=false` で署名成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS ビルドプロセスの安定性を向上させるため、プロビジョニングプロファイルのインストール処理を改善しました。
  * コード署名設定を最適化し、ビルドアーカイブ中のプロビジョニング更新を有効にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->