### PR TITLE
ci: Automatic signingにDistribution identity指定

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -350,9 +350,7 @@ jobs:
               -allowProvisioningUpdates \
               MARKETING_VERSION="$VERSION" \
               CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
-              CODE_SIGN_STYLE=Manual \
               CODE_SIGN_IDENTITY="Apple Distribution" \
-              PROVISIONING_PROFILE_SPECIFIER="" \
               || {
                 echo "❌ Archive failed"
                 exit 1


### PR DESCRIPTION
## Summary
Manual signing アプローチを撤回し、Automatic signing + `CODE_SIGN_IDENTITY="Apple Distribution"` オーバーライドに変更。

## Background
前回のManual signing (#99) では依存パッケージ（swift-crypto等）も Manual signing を要求してしまい失敗:
```
error: Signing for "swift-crypto_Crypto" requires a development team
error: "FinalHourglass" requires a provisioning profile
```

## Approach
- Xcodeプロジェクトの`CODE_SIGN_STYLE=Automatic`をそのまま利用
- `CODE_SIGN_IDENTITY="Apple Distribution"`のみオーバーライド
- `-allowProvisioningUpdates`でプロビジョニング自動解決

## Test plan
- [ ] マージ後 `gh workflow run ios-release.yml -f version=1.0.8 -f dry_run=false` で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)