### PR TITLE
ci: ASC APIキーでAutomatic signing Archive実現

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -320,6 +320,8 @@ jobs:
         env:
           VERSION: ${{ needs.validate.outputs.version }}
           BUILD_NUMBER: ${{ needs.validate.outputs.build_number }}
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           set -euo pipefail
           ARCHIVE_PATH=$RUNNER_TEMP/FinalHourglass.xcarchive
@@ -341,6 +343,9 @@ jobs:
                 exit 1
               }
           else
+            # Automatic signing + App Store Connect APIキーで
+            # Distribution証明書とプロファイルを自動解決
+            API_KEY_PATH=~/private_keys/AuthKey_${API_KEY_ID}.p8
             xcodebuild archive \
               -workspace FinalHourglass.xcworkspace \
               -scheme FinalHourglass \
@@ -348,9 +353,11 @@ jobs:
               -destination 'generic/platform=iOS' \
               -archivePath "$ARCHIVE_PATH" \
               -allowProvisioningUpdates \
+              -authenticationKeyPath "$API_KEY_PATH" \
+              -authenticationKeyID "$API_KEY_ID" \
+              -authenticationKeyIssuerID "$API_ISSUER_ID" \
               MARKETING_VERSION="$VERSION" \
               CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
-              CODE_SIGN_IDENTITY="Apple Distribution" \
               || {
                 echo "❌ Archive failed"
                 exit 1


### PR DESCRIPTION
## Summary
xcodebuild archiveに App Store Connect API認証パラメータを追加し、Automatic signingのままDistribution署名を実現。

## Background
| 試行 | アプローチ | 結果 |
|------|-----------|------|
| PR #99 | `CODE_SIGN_STYLE=Manual` | 依存パッケージ(swift-crypto)もManual要求→失敗 |
| PR #100 | `CODE_SIGN_IDENTITY="Apple Distribution"` | Automatic signing と矛盾→失敗 |
| **本PR** | ASC API認証 + Automatic signing | Xcodeが自動でDistributionプロファイル解決 |

## Changes
- `-authenticationKeyPath`, `-authenticationKeyID`, `-authenticationKeyIssuerID` をxcodebuild archiveに追加
- `CODE_SIGN_IDENTITY` オーバーライドを削除
- Automatic signing（プロジェクトデフォルト）を維持

## How it works
xcodebuildがASC APIキーを使ってApple Developer Portalと通信し:
1. Distributionプロファイルを自動ダウンロード
2. 証明書とプロファイルのマッチングを自動実行
3. 依存パッケージの署名もAutomatic signingで処理

## Test plan
- [ ] マージ後 `gh workflow run ios-release.yml -f version=1.0.8 -f dry_run=false` で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)