### PR TITLE
ci: ExportOptions.plistをXcode 16 + Manual signing対応に修正

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -386,28 +386,32 @@ jobs:
             exit 0
           fi
 
-          # CI用にExportOptions.plistを生成（リポジトリ直下のExportOptions.plistは.gitignore対象のため）
+          # CI用にExportOptions.plistを生成
           EXPORT_OPTIONS_PATH="$RUNNER_TEMP/ExportOptions.ci.plist"
-          cat > "$EXPORT_OPTIONS_PATH" <<'EOF'
+          PROFILE_NAME="${{ steps.profile.outputs.name }}"
+          cat > "$EXPORT_OPTIONS_PATH" << PLISTEOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
           <dict>
             <key>method</key>
-            <string>app-store</string>
+            <string>app-store-connect</string>
             <key>teamID</key>
             <string>N4UHXSGNLU</string>
             <key>signingStyle</key>
-            <string>automatic</string>
-            <key>uploadBitcode</key>
-            <false/>
+            <string>manual</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>com.AIUELAB.FinalHourglass</key>
+              <string>${PROFILE_NAME}</string>
+            </dict>
             <key>uploadSymbols</key>
             <true/>
             <key>stripSwiftSymbols</key>
             <true/>
           </dict>
           </plist>
-          EOF
+          PLISTEOF
           echo "📄 Using ExportOptions.plist: $EXPORT_OPTIONS_PATH"
 
           xcodebuild -exportArchive \


### PR DESCRIPTION
## Summary
Archive成功後のExport IPAステップが失敗していた問題を修正。

## Error
```
error: exportArchive exportOptionsPlist error for key "method" expected one {} but found app-store
```

## Changes
| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| method | `app-store` | `app-store-connect`（Xcode 16+） |
| signingStyle | `automatic` | `manual`（Manual signing対応） |
| provisioningProfiles | なし | Bundle ID → プロファイル名マッピング追加 |
| uploadBitcode | `false` | 削除（deprecated） |

## Test plan
- [ ] マージ後 `gh workflow run ios-release.yml -f version=1.0.8 -f dry_run=false` で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS リリースワークフローの内部設定を更新しました。App Store Connect の署名設定をより効率的に管理するため、CI/CD パイプラインの構成を改善しました。エンドユーザーへの直接的な影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->