### PR TITLE
ci: キーチェーンリスト保持とExport IPA診断強化

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -282,8 +282,8 @@ jobs:
               echo "This may cause codesign to fail. Continuing anyway..."
             }
 
-          # キーチェーンをデフォルトに追加
-          security list-keychain -d user -s $KEYCHAIN_PATH
+          # キーチェーンをデフォルトに追加（既存キーチェーンを保持）
+          security list-keychain -d user -s $KEYCHAIN_PATH $(security list-keychain -d user | tr -d '"')
 
           echo "✅ Distribution certificate installed"
 
@@ -413,12 +413,14 @@ jobs:
           </plist>
           PLISTEOF
           echo "📄 Using ExportOptions.plist: $EXPORT_OPTIONS_PATH"
+          echo "📄 ExportOptions.plist content:"
+          cat "$EXPORT_OPTIONS_PATH"
 
           xcodebuild -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
             -exportPath "$EXPORT_PATH" \
             -exportOptionsPlist "$EXPORT_OPTIONS_PATH" \
-            | xcpretty --color || {
+            || {
               echo "❌ IPA export failed"
               exit 1
             }


### PR DESCRIPTION
## Summary
Export IPAの "Unknown Distribution Error" を解消するための修正。

## Changes
1. **キーチェーンリスト**: 既存キーチェーンを保持して追加（システムキーチェーンが消えていた問題）
2. **ExportOptions.plist**: 内容をログ出力（デバッグ用）
3. **xcpretty除去**: exportArchiveの生出力を表示

## Test plan
- [ ] マージ後 `gh workflow run ios-release.yml -f version=1.0.8 -f dry_run=false` で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)