### PR TITLE
ci: exportメソッドをapp-storeに戻す

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -395,7 +395,7 @@ jobs:
           <plist version="1.0">
           <dict>
             <key>method</key>
-            <string>app-store-connect</string>
+            <string>app-store</string>
             <key>teamID</key>
             <string>N4UHXSGNLU</string>
             <key>signingStyle</key>


### PR DESCRIPTION
## Summary
`app-store-connect` は Xcode 16.4 で有効なメソッドではなかった。`app-store` に戻す。
前回 `app-store` で失敗したのはキーチェーンリストの問題が原因だった可能性（PR #106で修正済み）。

## Test plan
- [ ] マージ後 `gh workflow run ios-release.yml -f version=1.0.8 -f dry_run=false` で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)