### PR TITLE
ci: exportArchiveに-allowProvisioningUpdatesを追加

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -420,6 +420,7 @@ jobs:
             -archivePath "$ARCHIVE_PATH" \
             -exportPath "$EXPORT_PATH" \
             -exportOptionsPlist "$EXPORT_OPTIONS_PATH" \
+            -allowProvisioningUpdates \
             || {
               echo "❌ IPA export failed"
               exit 1


### PR DESCRIPTION
## Summary
`exportArchive` で "Unknown Distribution Error" が3回発生しExportが失敗。
`-allowProvisioningUpdates` を追加してプロビジョニング解決を許可。

## Test plan
- [ ] マージ後 `gh workflow run ios-release.yml -f version=1.0.8 -f dry_run=false` で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ビルド改善**
  * iOS アプリのエクスポート処理において、プロビジョニング プロファイルの更新がより確実に行われるようになりました。これにより、リリース プロセスの信頼性と安定性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->