### PR TITLE
ci: exportArchive Unknown Distribution Error診断強化

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -416,13 +416,29 @@ jobs:
           echo "📄 ExportOptions.plist content:"
           cat "$EXPORT_OPTIONS_PATH"
 
+          # Archive内容の診断
+          echo "🔍 Checking archive signing..."
+          codesign -dvv "$ARCHIVE_PATH/Products/Applications/FinalHourglass.app" 2>&1 || true
+          echo "🔍 Checking embedded profile..."
+          if [ -f "$ARCHIVE_PATH/Products/Applications/FinalHourglass.app/embedded.mobileprovision" ]; then
+            security cms -D -i "$ARCHIVE_PATH/Products/Applications/FinalHourglass.app/embedded.mobileprovision" | head -30
+          else
+            echo "⚠️ No embedded.mobileprovision found!"
+          fi
+
           xcodebuild -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
             -exportPath "$EXPORT_PATH" \
             -exportOptionsPlist "$EXPORT_OPTIONS_PATH" \
             -allowProvisioningUpdates \
-            || {
+            2>&1 || {
               echo "❌ IPA export failed"
+              # Distribution logsを出力
+              DIST_LOGS=$(find /var/folders -name "*.xcdistributionlogs" -maxdepth 5 2>/dev/null | tail -1)
+              if [ -n "$DIST_LOGS" ]; then
+                echo "📋 Distribution logs:"
+                find "$DIST_LOGS" -name "*.log" -exec cat {} \; 2>/dev/null | tail -50
+              fi
               exit 1
             }
 


### PR DESCRIPTION
## Summary
`IDEDistributionMethodManager` の "Unknown Distribution Error" の原因を特定するため、診断出力を追加。

## Diagnostics Added
1. Archive内のapp署名情報（codesign -dvv）
2. embedded.mobileprovision の内容
3. 失敗時のxcdistributionlogsの出力

## Test plan
- [ ] マージ後 v1.0.8 で実行し、ログから原因を特定

🤖 Generated with [Claude Code](https://claude.com/claude-code)