### PR TITLE
fix: ExportOptions.plist heredoc空白問題をPlistBuddy生成に変更

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -386,35 +386,27 @@ jobs:
             exit 0
           fi
 
-          # CI用にExportOptions.plistを生成
+          # CI用にExportOptions.plistをPlistBuddyで生成（heredoc空白問題を回避）
           EXPORT_OPTIONS_PATH="$RUNNER_TEMP/ExportOptions.ci.plist"
-          PROFILE_NAME="${{ steps.profile.outputs.name }}"
-          cat > "$EXPORT_OPTIONS_PATH" << PLISTEOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>method</key>
-            <string>app-store</string>
-            <key>teamID</key>
-            <string>N4UHXSGNLU</string>
-            <key>signingStyle</key>
-            <string>manual</string>
-            <key>provisioningProfiles</key>
-            <dict>
-              <key>com.AIUELAB.FinalHourglass</key>
-              <string>${PROFILE_NAME}</string>
-            </dict>
-            <key>uploadSymbols</key>
-            <true/>
-            <key>stripSwiftSymbols</key>
-            <true/>
-          </dict>
-          </plist>
-          PLISTEOF
-          echo "📄 Using ExportOptions.plist: $EXPORT_OPTIONS_PATH"
+          PROFILE_UUID="${{ steps.profile.outputs.uuid }}"
+          /usr/libexec/PlistBuddy -c "Clear dict" "$EXPORT_OPTIONS_PATH"
+          /usr/libexec/PlistBuddy -c "Add :method string app-store" "$EXPORT_OPTIONS_PATH"
+          /usr/libexec/PlistBuddy -c "Add :teamID string N4UHXSGNLU" "$EXPORT_OPTIONS_PATH"
+          /usr/libexec/PlistBuddy -c "Add :signingStyle string manual" "$EXPORT_OPTIONS_PATH"
+          /usr/libexec/PlistBuddy -c "Add :provisioningProfiles dict" "$EXPORT_OPTIONS_PATH"
+          /usr/libexec/PlistBuddy -c "Add :provisioningProfiles:com.AIUELAB.FinalHourglass string ${PROFILE_UUID}" "$EXPORT_OPTIONS_PATH"
+          /usr/libexec/PlistBuddy -c "Add :uploadSymbols bool true" "$EXPORT_OPTIONS_PATH"
+          /usr/libexec/PlistBuddy -c "Add :stripSwiftSymbols bool true" "$EXPORT_OPTIONS_PATH"
+
+          # Plist検証
+          echo "🔍 Validating ExportOptions.plist..."
+          plutil -lint "$EXPORT_OPTIONS_PATH"
           echo "📄 ExportOptions.plist content:"
           cat "$EXPORT_OPTIONS_PATH"
+          echo "🔍 Parsed plist values:"
+          /usr/libexec/PlistBuddy -c "Print :method" "$EXPORT_OPTIONS_PATH"
+          /usr/libexec/PlistBuddy -c "Print :teamID" "$EXPORT_OPTIONS_PATH"
+          /usr/libexec/PlistBuddy -c "Print :provisioningProfiles:com.AIUELAB.FinalHourglass" "$EXPORT_OPTIONS_PATH"
 
           # Archive内容の診断
           echo "🔍 Checking archive signing..."


### PR DESCRIPTION
## Summary

- ExportOptions.plist生成をheredocからPlistBuddyコマンドに変更し、XML先頭空白問題を根本解決
- provisioning profile指定をPROFILE_NAME→PROFILE_UUIDに変更（より確実）
- exportArchive実行前にplist検証ステップ（plutil -lint + PlistBuddy Print）を追加

## Root Cause

heredocのYAMLインデント（10スペース）がplistファイルの先頭に混入：
```
          <?xml version="1.0" encoding="UTF-8"?>   ← 先頭に10スペース
```
XML仕様では`<?xml`がファイル最初の文字でなければならず、xcodebuildのパーサーがplistを読めなかった。
結果、有効なexportメソッドが空セット`{}`となり「Unknown Distribution Error」が発生。

## Fix

PlistBuddyによるプログラム的なplist生成に切り替え：
```bash
/usr/libexec/PlistBuddy -c "Clear dict" "$EXPORT_OPTIONS_PATH"
/usr/libexec/PlistBuddy -c "Add :method string app-store" "$EXPORT_OPTIONS_PATH"
# ...
```
これによりXMLフォーマットが常に正しく生成される。

## Test plan

- [ ] `plutil -lint` がOKを返すこと
- [ ] plist内容に先頭空白がないこと（catで確認）
- [ ] `xcodebuild -exportArchive` が成功すること
- [ ] IPAファイルが生成されること
- [ ] TestFlightアップロードが成功すること

### ローカル検証済み
```
$ /usr/libexec/PlistBuddy -c "Clear dict" /tmp/test.plist
File Doesn't Exist, Will Create: /tmp/test.plist
$ plutil -lint /tmp/test.plist
/tmp/test.plist: OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS リリースワークフローの改善: ExportOptions.plist の生成プロセスを強化し、ビルドの信頼性と検証精度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->