### PR TITLE
ci: exportArchive method値をXcode 16.4対応のapp-store-connectに変更

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -390,7 +390,7 @@ jobs:
           EXPORT_OPTIONS_PATH="$RUNNER_TEMP/ExportOptions.ci.plist"
           PROFILE_UUID="${{ steps.profile.outputs.uuid }}"
           /usr/libexec/PlistBuddy -c "Clear dict" "$EXPORT_OPTIONS_PATH"
-          /usr/libexec/PlistBuddy -c "Add :method string app-store" "$EXPORT_OPTIONS_PATH"
+          /usr/libexec/PlistBuddy -c "Add :method string app-store-connect" "$EXPORT_OPTIONS_PATH"
           /usr/libexec/PlistBuddy -c "Add :teamID string N4UHXSGNLU" "$EXPORT_OPTIONS_PATH"
           /usr/libexec/PlistBuddy -c "Add :signingStyle string manual" "$EXPORT_OPTIONS_PATH"
           /usr/libexec/PlistBuddy -c "Add :provisioningProfiles dict" "$EXPORT_OPTIONS_PATH"


### PR DESCRIPTION
## Summary
- exportOptionsPlistの`method`値を`app-store`から`app-store-connect`に変更
- Xcode 14.3以降で`app-store`は非推奨化され、Xcode 16.4では`expected one {} but found app-store`エラーが発生
- PR #110のPlistBuddy修正によりplistパース問題は解決済み。残る問題はmethod値の非推奨化のみ

## Root Cause
CIログ（run #21815548404）で以下のエラーを確認:
```
error: exportArchive exportOptionsPlist error for key "method" expected one {} but found app-store
```

## Test plan
- [ ] CIワークフロー（`ios-release.yml`）が`Export IPA`ステップを成功すること
- [ ] TestFlightアップロードが完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores（その他）**
  * iOS リリースワークフローのエクスポート設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->