### PR TITLE
ci: SKIP_INSTALL=NOを本番Archiveに追加しGeneric Archive問題を解決

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -363,6 +363,7 @@ jobs:
               MARKETING_VERSION="$VERSION" \
               CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
               PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
+              SKIP_INSTALL=NO \
               || {
                 echo "❌ Archive failed"
                 exit 1
@@ -384,6 +385,19 @@ jobs:
             echo "⚠️ Skipping IPA export (dry-run mode - no signing credentials)"
             echo "ipa_path=" >> $GITHUB_OUTPUT
             exit 0
+          fi
+
+          # Archive種類の検証（Generic Xcode Archive検出 = TN3110）
+          echo "🔍 Verifying archive type..."
+          if /usr/libexec/PlistBuddy -c "Print :ApplicationProperties" "$ARCHIVE_PATH/Info.plist" 2>/dev/null; then
+            echo "✅ Valid application archive"
+          else
+            echo "❌ FATAL: Generic Xcode Archive detected (TN3110)"
+            echo "Info.plist contents:"
+            /usr/libexec/PlistBuddy -c "Print" "$ARCHIVE_PATH/Info.plist"
+            echo "Products directory:"
+            ls -laR "$ARCHIVE_PATH/Products/" 2>/dev/null || echo "No Products directory!"
+            exit 1
           fi
 
           # CI用にExportOptions.plistをPlistBuddyで生成（heredoc空白問題を回避）


### PR DESCRIPTION
## Summary
- 本番ArchiveコマンドにSKIP_INSTALL=NOを追加（Generic Xcode Archive問題の解決）
- Export IPA前にApplicationProperties検証ステップを追加（TN3110対応）

## Root Cause
`xcodebuild archive`でSKIP_INSTALLが未指定のため、生成されたxcarchiveが
「Generic Xcode Archive」として認識されていた。Generic Archiveには有効な
distribution methodがゼロのため、`expected one of {} but found app-store-connect`
エラーが発生。

dry-runブランチ(L348)にはSKIP_INSTALL=NOがあったが、本番ブランチ(L357-365)にはなかった。

## References
- [Apple TN3110: Resolving generic Xcode archive issue](https://developer.apple.com/documentation/technotes/tn3110-resolving-generic-xcode-archive-issue)
- [fastlane#10559](https://github.com/fastlane/fastlane/issues/10559)

## Test plan
- [ ] CIワークフローのArchive後にApplicationProperties検証がpass
- [ ] Export IPAステップが成功
- [ ] TestFlightアップロードが完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS ビルドプロセスの検証を強化しました。アーカイブの整合性チェックを追加し、不正なアーカイブの検出時に詳細なエラー情報を表示します。これにより、リリースプロセスの信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->