### PR TITLE
ci: SKIP_INSTALL=NOをxcconfigに移動しGeneric Archive問題を解決

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -345,7 +345,6 @@ jobs:
               MARKETING_VERSION="$VERSION" \
               CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
               CODE_SIGNING_ALLOWED=NO \
-              SKIP_INSTALL=NO \
               | xcpretty --color || {
                 echo "❌ Archive failed (dry-run)"
                 exit 1
@@ -363,7 +362,6 @@ jobs:
               MARKETING_VERSION="$VERSION" \
               CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
               PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
-              SKIP_INSTALL=NO \
               || {
                 echo "❌ Archive failed"
                 exit 1

--- a/ios-apps/final-hourglass/Config/Release.xcconfig
+++ b/ios-apps/final-hourglass/Config/Release.xcconfig
@@ -24,6 +24,9 @@ DEPLOYMENT_POSTPROCESSING = NO
 // Validate product settings
 VALIDATE_PRODUCT = YES
 
+// Archive用: アプリをProducts/Applications/にインストールする（TN3110対応）
+SKIP_INSTALL = NO
+
 // Bitcode is deprecated by Apple (Xcode 14+)
 ENABLE_BITCODE = NO
 


### PR DESCRIPTION
## Summary
- コマンドラインの`SKIP_INSTALL=NO`をRelease.xcconfigに移動
- SPMパッケージの.oファイルがProducts/にインストールされてGeneric Archiveになる問題を解決

## Root Cause
CIログ（run #21823196715）の診断ステップで判明：

```
❌ FATAL: Generic Xcode Archive detected (TN3110)
Products/Users/runner/Objects/
  Auth.o, Clocks.o, Functions.o, ... (SPMパッケージの.oファイル)
```

`xcodebuild archive ... SKIP_INSTALL=NO` はコマンドラインから指定すると
**全ターゲット**（SPMパッケージ含む）に一律適用される。その結果：
- SPMパッケージの.oファイルが `Products/Users/runner/Objects/` にインストール
- アプリが `Products/Applications/` に配置されない
- xcarchiveが「Generic Xcode Archive」として認識される
- exportArchiveで有効なdistribution methodがゼロ → `expected one {} but found app-store-connect`

## Fix
- Release.xcconfigに `SKIP_INSTALL = NO` を追加（アプリターゲットのみに適用）
- コマンドラインから `SKIP_INSTALL=NO` を削除（dry-run/本番両方）

## References
- [Apple TN3110: Resolving generic Xcode archive issue](https://developer.apple.com/documentation/technotes/tn3110-resolving-generic-xcode-archive-issue)

## Test plan
- [ ] Archive後のApplicationProperties検証がpass（Valid application archive）
- [ ] Export IPAステップが成功
- [ ] TestFlightアップロードが完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * iOS リリースビルドの構成設定を更新しました。ビルドシステムの構成を調整し、アーカイブ処理に関連する設定を再整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->