### PR TITLE
ci: INSTALL_PATHを追加しProducts/Applications/にアプリを配置

### DIFF
--- a/ios-apps/final-hourglass/Config/Release.xcconfig
+++ b/ios-apps/final-hourglass/Config/Release.xcconfig
@@ -26,6 +26,7 @@ VALIDATE_PRODUCT = YES
 
 // Archive用: アプリをProducts/Applications/にインストールする（TN3110対応）
 SKIP_INSTALL = NO
+INSTALL_PATH = $(LOCAL_APPS_DIR)
 
 // Bitcode is deprecated by Apple (Xcode 14+)
 ENABLE_BITCODE = NO


### PR DESCRIPTION
## Summary
- Release.xcconfigに`INSTALL_PATH = $(LOCAL_APPS_DIR)`を追加
- Products/が空でGeneric Archiveになる問題を解決

## Root Cause
CIログ（run #21823559301）:
```
❌ FATAL: Generic Xcode Archive detected (TN3110)
Info.plist: ArchiveVersion=2, Name=FinalHourglass, SchemeName=FinalHourglass
Products directory: total 0  ← 完全に空！
```

`SKIP_INSTALL=NO`だけではアプリがProducts/にインストールされない。
`INSTALL_PATH`が未設定のため、Xcodeがインストール先を決定できなかった。

## Test plan
- [ ] Archive後のProducts/Applications/FinalHourglass.appが存在
- [ ] ApplicationProperties検証がpass
- [ ] Export IPAが成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * アーカイブビルドのインストールパス設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->