### PR TITLE
ci: SKIP_INSTALL+INSTALL_PATHをArchiveコマンドに追加

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -362,6 +362,8 @@ jobs:
               MARKETING_VERSION="$VERSION" \
               CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
               PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
+              SKIP_INSTALL=NO \
+              INSTALL_PATH=/Applications \
               || {
                 echo "❌ Archive failed"
                 exit 1


### PR DESCRIPTION
## Summary
- Archiveコマンドに`SKIP_INSTALL=NO`と`INSTALL_PATH=/Applications`を同時追加
- xcconfigでの設定が効かなかったため、コマンドラインで直接指定

## Root Cause
- PR #113: xcconfigに`SKIP_INSTALL=NO`追加 → Products/が空のまま（効かなかった）
- PR #114: `INSTALL_PATH=$(LOCAL_APPS_DIR)`追加 → 同上

xcconfigがArchive時のアプリターゲットに適用されていない可能性が高い。
コマンドラインでの直接指定が最も確実。

`INSTALL_PATH=/Applications`を同時指定することで、アプリが
`Products/Applications/FinalHourglass.app`に正しく配置される。

## Test plan
- [ ] Archive後にApplicationProperties検証がpass
- [ ] Export IPAが成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)