### PR TITLE
ci: Archive検証をProducts/Applications/存在チェックに変更

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -387,14 +387,23 @@ jobs:
             exit 0
           fi
 
-          # Archive種類の検証（Generic Xcode Archive検出 = TN3110）
+          # Archive種類の検証
           echo "🔍 Verifying archive type..."
           if /usr/libexec/PlistBuddy -c "Print :ApplicationProperties" "$ARCHIVE_PATH/Info.plist" 2>/dev/null; then
-            echo "✅ Valid application archive"
+            echo "✅ Valid application archive (ApplicationProperties found)"
           else
-            echo "❌ FATAL: Generic Xcode Archive detected (TN3110)"
+            echo "⚠️ ApplicationProperties not found in Info.plist"
             echo "Info.plist contents:"
             /usr/libexec/PlistBuddy -c "Print" "$ARCHIVE_PATH/Info.plist"
+          fi
+
+          # Products/Applications/にアプリが存在するか確認
+          echo "🔍 Checking Products/Applications/..."
+          if [ -d "$ARCHIVE_PATH/Products/Applications/FinalHourglass.app" ]; then
+            echo "✅ App bundle found in Products/Applications/"
+            ls -la "$ARCHIVE_PATH/Products/Applications/"
+          else
+            echo "❌ FATAL: App bundle not found in Products/Applications/"
             echo "Products directory:"
             ls -laR "$ARCHIVE_PATH/Products/" 2>/dev/null || echo "No Products directory!"
             exit 1


### PR DESCRIPTION
## Summary
- ApplicationPropertiesチェックをexit 1から警告のみに降格
- 代わりにProducts/Applications/FinalHourglass.appディレクトリの存在を確認
- アプリが正しく配置されていればexportArchiveの実行を許可

## Background
run 21825349762で`Products/Applications/`にアプリが正しく配置されている（total 19264）にもかかわらず、`ApplicationProperties`キーの欠落で`exit 1`してexportArchiveに到達できなかった。

`SKIP_INSTALL=NO` + `INSTALL_PATH=/Applications`でアプリは正しくProducts/に配置されるが、xcarchiveのInfo.plistにApplicationPropertiesが自動生成されないケースがある。実際にexportArchiveが成功するかはexportArchiveに委ねるべき。

## Test plan
- [ ] CIワークフロー実行（v1.0.7）でexportArchiveに到達することを確認
- [ ] exportArchiveの成功/失敗結果を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)