### PR TITLE
ci: SKIP_INSTALLをアプリターゲットのみに適用しGeneric Archive問題を解決

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -362,8 +362,6 @@ jobs:
               MARKETING_VERSION="$VERSION" \
               CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
               PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
-              SKIP_INSTALL=NO \
-              INSTALL_PATH=/Applications \
               || {
                 echo "❌ Archive failed"
                 exit 1

--- a/ios-apps/final-hourglass/FinalHourglass.xcodeproj/project.pbxproj
+++ b/ios-apps/final-hourglass/FinalHourglass.xcodeproj/project.pbxproj
@@ -718,6 +718,8 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				SKIP_INSTALL = NO;
+				INSTALL_PATH = "$(LOCAL_APPS_DIR)";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Summary
- `SKIP_INSTALL=NO`と`INSTALL_PATH`をproject.pbxprojのアプリターゲットRelease設定に直接追加
- CIワークフローのArchiveコマンドから`SKIP_INSTALL=NO`と`INSTALL_PATH=/Applications`を削除

## Root Cause
コマンドラインの`SKIP_INSTALL=NO INSTALL_PATH=/Applications`は**全ターゲット**（SPMパッケージ含む）に適用される。
SPMパッケージの成果物がProducts/に配置されることで、xcarchiveがGeneric Xcode Archive扱いになり、
`ApplicationProperties`が生成されず、`exportArchive`が失敗していた（Apple TN3110）。

## Fix
project.pbxprojのアプリターゲット（FinalHourglass）のRelease設定にのみ`SKIP_INSTALL=NO`を追加することで：
- メインアプリ → `SKIP_INSTALL=NO`（Products/Applications/に配置される）
- SPMパッケージ → Xcodeデフォルト（`SKIP_INSTALL=YES`、Products/に配置されない）
- `ApplicationProperties`が正しく生成される

## Test plan
- [ ] CIワークフロー実行でexportArchiveが成功することを確認
- [ ] TestFlightアップロード成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * iOS リリースワークフローの内部構成を調整しました。

**注:** このリリースにはエンドユーザーに対する目に見える変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->