### PR TITLE
chore: person_growth dry-runファイルをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,6 +360,9 @@ preserved/data/dashboard_data_v11.json
 preserved/data/dashboard_data_v11.json.gz
 # Large report files (>2MB)
 src/reports/real_person_factcheck_parsed.json
+
+# Person growth dry-run files (auto-generated, ~4.6MB)
+reports/person_growth/person_growth_dry-run_*.json
 src/reports/fictional_llm_classification_results.csv
 src/reports/fictional_regenerate_results.json
 src/reports/fictional_rule_violations.csv


### PR DESCRIPTION
## Summary
- `reports/person_growth/person_growth_dry-run_*.json` を `.gitignore` に追加
- SAGE dry-run実行で自動生成される一時ファイル（1,170ファイル、4.6MB）が未追跡で蓄積していた

## Test plan
- [ ] `.gitignore` の差分が正しいこと
- [ ] 新たにdry-runファイルが生成されても `git status` に表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の改善**
  * 開発ワークフローの効率化のため、Git管理から除外するファイルパターンを更新しました。リポジトリ管理がより効率的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->