### PR TITLE
fix: fastlane metadata レーンに API Key 認証を追加

### DIFF
--- a/ios-apps/final-hourglass/fastlane/Fastfile
+++ b/ios-apps/final-hourglass/fastlane/Fastfile
@@ -14,12 +14,26 @@ platform :ios do
   end
 
   desc "メタデータのみApp Store Connectにアップロード"
-  lane :metadata do
-    deliver(
-      skip_binary_upload: true,
-      skip_screenshots: true,
-      force: true
-    )
+  lane :metadata do |options|
+    if options[:api_key_path]
+      api_key = app_store_connect_api_key(
+        key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
+        issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
+        key_filepath: options[:api_key_path]
+      )
+      deliver(
+        api_key: api_key,
+        skip_binary_upload: true,
+        skip_screenshots: true,
+        force: true
+      )
+    else
+      deliver(
+        skip_binary_upload: true,
+        skip_screenshots: true,
+        force: true
+      )
+    end
   end
 
   desc "メタデータとスクリーンショットをアップロード"


### PR DESCRIPTION
## Summary

- fastlane `metadata` レーンに `api_key_path` オプションを追加し、App Store Connect API Key認証に対応
- CI環境（GitHub Actions）で `workflow_dispatch` 経由のメタデータアップロードが動作するよう修正
- ローカル実行時（`api_key_path` 未指定）は従来のApple ID認証にフォールバック

## Test plan

- [ ] `gh workflow run ios-fastlane.yml --ref main -f job=metadata` でCI環境でのメタデータアップロードが成功すること
- [ ] App Store ConnectでASO情報（subtitle/keywords/description）の更新を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * メタデータレーンがオプションパラメータに対応しました。APIキーパスを指定することで、異なる認証方式での実行が可能になりました。既存の動作との互換性も保持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->