### PR TITLE
fix: fastlane deliver に edit_live オプション追加

### DIFF
--- a/.github/workflows/ios-fastlane.yml
+++ b/.github/workflows/ios-fastlane.yml
@@ -126,7 +126,7 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           bundle exec fastlane metadata \
-            api_key_path:~/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8
+            api_key_path:"$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
 
       - name: Upload Summary
         if: always()

--- a/ios-apps/final-hourglass/fastlane/Fastfile
+++ b/ios-apps/final-hourglass/fastlane/Fastfile
@@ -23,12 +23,14 @@ platform :ios do
       )
       deliver(
         api_key: api_key,
+        edit_live: true,
         skip_binary_upload: true,
         skip_screenshots: true,
         force: true
       )
     else
       deliver(
+        edit_live: true,
         skip_binary_upload: true,
         skip_screenshots: true,
         force: true
@@ -40,6 +42,7 @@ platform :ios do
   lane :upload_metadata_and_screenshots do
     screenshots
     deliver(
+      edit_live: true,
       skip_binary_upload: true,
       force: true
     )


### PR DESCRIPTION
## Summary

- 全3箇所の `deliver()` 呼び出しに `edit_live: true` オプションを追加
- `ios-fastlane.yml` の `api_key_path` でチルダ (`~`) を `$HOME` に修正

## Problem

v1.0.9 リリース後に `fastlane metadata` を実行すると、以下のエラーが発生:

```
Cannot find edit app store version
```

これは `deliver` がデフォルトで「編集可能なバージョン（Prepare for Submission状態）」を探すが、v1.0.9 は既にリリース済み（Ready for Distribution）のため見つからないことが原因。

また、`api_key_path` でチルダ (`~`) を使用していたが、fastlane のオプション解析ではシェル展開が行われないため、パスが正しく解決されない可能性があった。

## Solution

- `edit_live: true` を指定することで、リリース済みバージョンのメタデータを直接編集可能に
- `api_key_path` を `$HOME` 環境変数を使った形式に修正し、確実にパスが展開されるようにした

## Changed Files

| File | Change |
|------|--------|
| `ios-apps/final-hourglass/fastlane/Fastfile` | 3箇所の `deliver()` に `edit_live: true` 追加 |
| `.github/workflows/ios-fastlane.yml` | `api_key_path` のチルダを `$HOME` に修正 |

## Test plan

- [ ] `bundle exec fastlane metadata` が v1.0.9 リリース済み状態で正常にメタデータを更新できることを確認
- [ ] GitHub Actions workflow_dispatch で metadata ジョブを手動実行して成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOS アプリのデプロイメントワークフローにおいて、API キーのパス指定を改善しました。
  * アプリメタデータとスクリーンショットのアップロードプロセス中に、ライブアプリの編集を有効化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->