### PR TITLE
ci: security-scan ジョブに Gitleaks シークレットスキャン統合

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks Secret Scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

- **Problem**: `ci.yml` の `security-scan` ジョブにはコメントで Gitleaks への言及があるが、実際のステップが未実装
- **Problem**: `ci-enhanced.yml` には Gitleaks が存在するが、`main`/`develop` ブランチのみ対象で `chore/*` ブランチが漏れている
- **Solution**: `ci.yml` の `security-scan` ジョブに `gitleaks/gitleaks-action@v2` ステップを追加し、全 push トリガーで包括的にシークレットスキャンを実行

## Changes

- `security-scan` ジョブの checkout に `fetch-depth: 0` を追加（フル Git 履歴でのスキャン用）
- checkout と Python セットアップの間に Gitleaks Secret Scan ステップを挿入
- `GITHUB_TOKEN` を env で渡してスキャン結果を PR にレポート

## Test plan

- [ ] CI ワークフローが正常に実行されることを確認
- [ ] Gitleaks ステップが `security-scan` ジョブ内で正しく動作することを確認
- [ ] シークレットが含まれていないリポジトリでスキャンが pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI パイプラインを更新し、リポジトリ履歴の完全取得を有効化しました。これにより履歴を用いた検証が可能になりました。
* **Security**
  * CI にシークレット漏えい検出の自動スキャンを追加し、誤った機密情報の混入を早期に検知できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->