### PR TITLE
fix: edit_live を false に変更（配信準備完了状態対応）

### DIFF
--- a/ios-apps/final-hourglass/fastlane/Fastfile
+++ b/ios-apps/final-hourglass/fastlane/Fastfile
@@ -23,14 +23,14 @@ platform :ios do
       )
       deliver(
         api_key: api_key,
-        edit_live: true,
+        edit_live: false,
         skip_binary_upload: true,
         skip_screenshots: true,
         force: true
       )
     else
       deliver(
-        edit_live: true,
+        edit_live: false,
         skip_binary_upload: true,
         skip_screenshots: true,
         force: true


### PR DESCRIPTION
## Summary
- fastlane deliver の `edit_live` を `true` → `false` に変更
- App Store Connect が「配信準備完了」状態の場合、`edit_live: true` ではライブバージョン編集リソースが見つからず `Cannot find edit app info` でタイムアウトする
- `edit_live: false` で準備中バージョンにメタデータを直接適用

## Root Cause
metadata ワークフロー (run #22677047323) が以下のエラーで15分後にタイムアウト:
```
Cannot find edit app info... Retrying after 300 seconds (remaining: 2)
Cannot find edit app info... Retrying after 300 seconds (remaining: 1)
```

## Test plan
- [ ] CI required checks パス
- [ ] マージ後 `gh workflow run ios-fastlane.yml --ref main -f job=metadata` で再実行
- [ ] App Store Connect でメタデータ更新確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOSアプリケーションのビルド設定を更新し、メタデータ配信プロセスを調整しました。複数の配信パスに対してリリースワークフロー関連の設定値を変更し、配信動作を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->