### PR TITLE
fix: metadata レーンに app_version パラメータ追加

### DIFF
--- a/.github/workflows/ios-fastlane.yml
+++ b/.github/workflows/ios-fastlane.yml
@@ -16,6 +16,10 @@ on:
           - screenshots
           - metadata
           - both
+      version:
+        description: 'App Store バージョン（例: 1.0.10）新バージョン作成時に指定'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -124,9 +128,13 @@ jobs:
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_VERSION: ${{ github.event.inputs.version }}
         run: |
-          bundle exec fastlane metadata \
-            api_key_path:"$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          ARGS="api_key_path:$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          if [ -n "$APP_VERSION" ]; then
+            ARGS="$ARGS app_version:$APP_VERSION"
+          fi
+          bundle exec fastlane metadata $ARGS
 
       - name: Upload Summary
         if: always()

--- a/ios-apps/final-hourglass/fastlane/Fastfile
+++ b/ios-apps/final-hourglass/fastlane/Fastfile
@@ -15,27 +15,25 @@ platform :ios do
 
   desc "メタデータのみApp Store Connectにアップロード"
   lane :metadata do |options|
+    deliver_options = {
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      force: true
+    }
+
+    if options[:app_version]
+      deliver_options[:app_version] = options[:app_version]
+    end
+
     if options[:api_key_path]
-      api_key = app_store_connect_api_key(
+      deliver_options[:api_key] = app_store_connect_api_key(
         key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
         issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
         key_filepath: options[:api_key_path]
       )
-      deliver(
-        api_key: api_key,
-        edit_live: false,
-        skip_binary_upload: true,
-        skip_screenshots: true,
-        force: true
-      )
-    else
-      deliver(
-        edit_live: false,
-        skip_binary_upload: true,
-        skip_screenshots: true,
-        force: true
-      )
     end
+
+    deliver(deliver_options)
   end
 
   desc "メタデータとスクリーンショットをアップロード"


### PR DESCRIPTION
## Summary
- fastlane metadata レーンに `app_version` パラメータを追加
- ワークフローに `version` 入力フィールドを追加
- 「配信準備完了」状態で新バージョンを作成しメタデータを適用可能に

## Root Cause
App Store Connect が「配信準備完了」状態では:
- `edit_live: true` → `Cannot find edit app info`（ライブ版なし）
- `edit_live: false` → `Cannot find edit app store version`（準備中バージョンなし）

`app_version` を指定することで、新バージョンを自動作成してメタデータを適用できる。

## Test plan
- [ ] CI required checks パス
- [ ] マージ後 `gh workflow run ios-fastlane.yml --ref main -f job=metadata -f version=1.0.10` で実行
- [ ] App Store Connect で v1.0.10 が作成されメタデータが反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * iOSアプリのメタデータアップロードプロセスのパラメータ処理を統一し、コードの複雑さを軽減しました。

* **Chores**
  * CI/CDパイプラインにおいて、iOSビルドとメタデータアップロード時にバージョンを指定できるオプション機能を追加しました。これによりビルドパイプラインの柔軟性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->