### PR TITLE
fix: primary_category を新形式に更新

### DIFF
--- a/ios-apps/final-hourglass/fastlane/metadata/primary_category.txt
+++ b/ios-apps/final-hourglass/fastlane/metadata/primary_category.txt
@@ -1,1 +1,1 @@
-MZGenre.Lifestyle
+LIFESTYLE


### PR DESCRIPTION
## Summary
- `MZGenre.Lifestyle` (deprecated) → `LIFESTYLE` (新形式) に更新
- App Store Connect API がカテゴリ重複エラーを返す原因を修正

## Root Cause
fastlane deliver が旧形式カテゴリ `MZGenre.Lifestyle` を新形式に内部変換する際、
重複カテゴリとして扱われ以下のエラーが発生:
```
You may not select the same category twice for your app. - /data/relationships/primaryCategory
```

## Test plan
- [ ] CI required checks パス
- [ ] マージ後 metadata ワークフロー再実行で成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)