### PR TITLE
fix: カテゴリ重複エラーを回避（primary_category.txt 削除）

### DIFF
--- a/ios-apps/final-hourglass/fastlane/metadata/primary_category.txt
+++ b/ios-apps/final-hourglass/fastlane/metadata/primary_category.txt
@@ -1,1 +1,0 @@
-LIFESTYLE


### PR DESCRIPTION
## Summary
- `primary_category.txt` を削除してカテゴリ更新をスキップ
- App Store Connect で既に設定済みのカテゴリを維持

## Root Cause
fastlane deliver が `primary_category.txt` の値をAPIに送信する際、
App Store Connect 側で primary/secondary に同じカテゴリが設定されていると:
```
You may not select the same category twice for your app. - /data/relationships/primaryCategory
```

## Test plan
- [ ] CI required checks パス
- [ ] マージ後 metadata ワークフロー再実行で成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iOSアプリのメタデータから、カテゴリ指定情報を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->