### PR TITLE
fix: Deliverfile から price_tier/automatic_release を削除

### DIFF
--- a/ios-apps/final-hourglass/fastlane/Deliverfile
+++ b/ios-apps/final-hourglass/fastlane/Deliverfile
@@ -9,7 +9,3 @@ submission_information({
   content_rights_contains_third_party_content: true,
   content_rights_has_rights: true
 })
-
-# リリース設定
-automatic_release(false)
-price_tier(0)


### PR DESCRIPTION
## Summary
- `price_tier(0)` と `automatic_release(false)` を Deliverfile から削除
- fastlane 2.232.1 の API 互換性問題を回避

## Root Cause
`price_tier` 設定が fastlane 内部で `availableInNewTerritories` 属性を送信し、
新しい App Store Connect API がこの属性を拒否:
```
'availableInNewTerritories' is not an attribute on the resource 'apps'
```

## Test plan
- [ ] CI required checks パス
- [ ] マージ後 metadata ワークフロー成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)