### PR TITLE
fix: rating_config から seventeenPlus 削除

### DIFF
--- a/ios-apps/final-hourglass/fastlane/rating_config.json
+++ b/ios-apps/final-hourglass/fastlane/rating_config.json
@@ -12,6 +12,5 @@
   "sexualContentGraphicAndNudity": "NONE",
   "unrestrictedWebAccess": false,
   "gambling": false,
-  "contests": false,
-  "seventeenPlus": false
+  "contests": false
 }


### PR DESCRIPTION
## Summary
- `seventeenPlus` は `ageRatingDeclarations` リソースの有効な属性ではない
- API エラー回避のため削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)