### PR TITLE
fix: rating_config.json を公式形式に準拠

### DIFF
--- a/ios-apps/final-hourglass/fastlane/rating_config.json
+++ b/ios-apps/final-hourglass/fastlane/rating_config.json
@@ -1,16 +1,16 @@
 {
+  "alcoholTobaccoOrDrugUseOrReferences": "NONE",
+  "contests": "NONE",
+  "gamblingSimulated": "NONE",
+  "horrorOrFearThemes": "NONE",
+  "matureOrSuggestiveThemes": "NONE",
+  "medicalOrTreatmentInformation": "NONE",
+  "profanityOrCrudeHumor": "NONE",
+  "sexualContentGraphicAndNudity": "NONE",
+  "sexualContentOrNudity": "NONE",
   "violenceCartoonOrFantasy": "NONE",
   "violenceRealistic": "NONE",
   "violenceRealisticProlongedGraphicOrSadistic": "NONE",
-  "profanityOrCrudeHumor": "NONE",
-  "matureOrSuggestiveThemes": "NONE",
-  "horrorOrFearThemes": "NONE",
-  "medicalOrTreatmentInformation": "NONE",
-  "alcoholTobaccoOrDrugUseOrReferences": "NONE",
-  "gamblingSimulated": "NONE",
-  "sexualContentOrNudity": "NONE",
-  "sexualContentGraphicAndNudity": "NONE",
-  "unrestrictedWebAccess": false,
   "gambling": false,
-  "contests": false
+  "unrestrictedWebAccess": false
 }


### PR DESCRIPTION
## Summary
- `contests` を `false` (BOOLEAN) → `"NONE"` (STRING) に修正
- fastlane 公式の example_rating_config.json に準拠

## Test plan
- [ ] CI パス → マージ → metadata ワークフロー成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)