### PR TITLE
fix: TSan有効スキーム + FeedbackCategoryテスト集約 (#163, #164)

### DIFF
--- a/.github/workflows/ios-tsan.yml
+++ b/.github/workflows/ios-tsan.yml
@@ -1,0 +1,42 @@
+name: iOS TSan Tests
+on:
+  schedule:
+    - cron: '0 3 * * 1'  # 毎週月曜 12:00 JST
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'ios-apps/**/AnalyticsManager*.swift'
+      - 'ios-apps/**/*Thread*.swift'
+      - 'ios-apps/**/*Concurrent*.swift'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-tsan-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  tsan-test:
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-ios
+        with:
+          install-xcpretty: 'true'
+          cache-derived-data: 'true'
+      - name: Run TSan Tests
+        run: |
+          set -o pipefail
+          cd ios-apps/final-hourglass
+          xcodebuild test \
+            -workspace FinalHourglass.xcworkspace \
+            -scheme FinalHourglass-TSan \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -only-testing:FinalHourglassTests/AnalyticsManagerTests \
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | tee tsan-test.log | xcpretty --color
+      - name: Show TSan log on failure
+        if: failure()
+        run: tail -200 ios-apps/final-hourglass/tsan-test.log || true

--- a/ios-apps/final-hourglass/FinalHourglass.xcodeproj/xcshareddata/xcschemes/FinalHourglass-TSan.xcscheme
+++ b/ios-apps/final-hourglass/FinalHourglass.xcodeproj/xcshareddata/xcschemes/FinalHourglass-TSan.xcscheme
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "84B6A96E2DDAB575000C3E82"
+               BuildableName = "FinalHourglass.app"
+               BlueprintName = "FinalHourglass"
+               ReferencedContainer = "container:FinalHourglass.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F01A37686DFD6346ED72FBB"
+               BuildableName = "FinalHourglassTests.xctest"
+               BlueprintName = "FinalHourglassTests"
+               ReferencedContainer = "container:FinalHourglass.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F6789A001UITST"
+               BuildableName = "FinalHourglassUITests.xctest"
+               BlueprintName = "FinalHourglassUITests"
+               ReferencedContainer = "container:FinalHourglass.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      threadSanitizerEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F01A37686DFD6346ED72FBB"
+               BuildableName = "FinalHourglassTests.xctest"
+               BlueprintName = "FinalHourglassTests"
+               ReferencedContainer = "container:FinalHourglass.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F6789A001UITST"
+               BuildableName = "FinalHourglassUITests.xctest"
+               BlueprintName = "FinalHourglassUITests"
+               ReferencedContainer = "container:FinalHourglass.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "84B6A96E2DDAB575000C3E82"
+            BuildableName = "FinalHourglass.app"
+            BlueprintName = "FinalHourglass"
+            ReferencedContainer = "container:FinalHourglass.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "84B6A96E2DDAB575000C3E82"
+            BuildableName = "FinalHourglass.app"
+            BlueprintName = "FinalHourglass"
+            ReferencedContainer = "container:FinalHourglass.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios-apps/final-hourglass/FinalHourglassTests/AnalyticsManagerTests.swift
+++ b/ios-apps/final-hourglass/FinalHourglassTests/AnalyticsManagerTests.swift
@@ -59,8 +59,8 @@ final class AnalyticsManagerTests: XCTestCase {
         sut.trackShare(method: "clipboard")
     }
 
-    // MARK: - Thread Safety Tests (TSan推奨)
-    // Note: クラッシュ有無のみ検証。データレース検出には TSan 有効スキームでの実行が必要
+    // MARK: - Thread Safety Tests
+    // TSan 有効スキーム (FinalHourglass-TSan) + ios-tsan.yml で CI 実行
 
     func testConfigure_concurrentCalls_doesNotCrash() {
         let sut = AnalyticsManager.shared

--- a/ios-apps/final-hourglass/FinalHourglassTests/FeedbackFormViewTests.swift
+++ b/ios-apps/final-hourglass/FinalHourglassTests/FeedbackFormViewTests.swift
@@ -103,8 +103,7 @@ final class FeedbackFormViewTests: XCTestCase {
     }
 
     // MARK: - FeedbackCategory Tests
-    // Note: displayName/icon テストは ReviewManagerTests 側に既存（レビューフロー文脈で追加された経緯）。
-    // ここでは rawValue/identifiable を補完。将来的には本ファイルに集約が望ましい
+    // ReviewManagerTests から集約済み（allCases / displayName / icon / rawValue / identifiable）
 
     func testFeedbackCategory_rawValues() {
         XCTAssertEqual(FeedbackCategory.bugReport.rawValue, "bug_report")
@@ -117,5 +116,23 @@ final class FeedbackFormViewTests: XCTestCase {
         for category in FeedbackCategory.allCases {
             XCTAssertEqual(category.id, category.rawValue)
         }
+    }
+
+    func testFeedbackCategory_allCasesCount() {
+        XCTAssertEqual(FeedbackCategory.allCases.count, 4)
+    }
+
+    func testFeedbackCategory_displayNames() {
+        XCTAssertEqual(FeedbackCategory.bugReport.displayName, "バグ報告")
+        XCTAssertEqual(FeedbackCategory.featureRequest.displayName, "機能要望")
+        XCTAssertEqual(FeedbackCategory.usability.displayName, "使いにくい")
+        XCTAssertEqual(FeedbackCategory.other.displayName, "その他")
+    }
+
+    func testFeedbackCategory_icons() {
+        XCTAssertEqual(FeedbackCategory.bugReport.icon, "ladybug")
+        XCTAssertEqual(FeedbackCategory.featureRequest.icon, "lightbulb")
+        XCTAssertEqual(FeedbackCategory.usability.icon, "hand.tap")
+        XCTAssertEqual(FeedbackCategory.other.icon, "ellipsis.circle")
     }
 }

--- a/ios-apps/final-hourglass/FinalHourglassTests/ReviewManagerTests.swift
+++ b/ios-apps/final-hourglass/FinalHourglassTests/ReviewManagerTests.swift
@@ -434,26 +434,6 @@ final class ReviewManagerTests: XCTestCase {
         XCTAssertFalse(manager.canRequestReview())
     }
 
-    // MARK: - FeedbackCategory Tests
-
-    func testFeedbackCategory_allCasesCount() {
-        XCTAssertEqual(FeedbackCategory.allCases.count, 4)
-    }
-
-    func testFeedbackCategory_displayNames() {
-        XCTAssertEqual(FeedbackCategory.bugReport.displayName, "バグ報告")
-        XCTAssertEqual(FeedbackCategory.featureRequest.displayName, "機能要望")
-        XCTAssertEqual(FeedbackCategory.usability.displayName, "使いにくい")
-        XCTAssertEqual(FeedbackCategory.other.displayName, "その他")
-    }
-
-    func testFeedbackCategory_icons() {
-        XCTAssertEqual(FeedbackCategory.bugReport.icon, "ladybug")
-        XCTAssertEqual(FeedbackCategory.featureRequest.icon, "lightbulb")
-        XCTAssertEqual(FeedbackCategory.usability.icon, "hand.tap")
-        XCTAssertEqual(FeedbackCategory.other.icon, "ellipsis.circle")
-    }
-
     // MARK: - coarsenAgeGroup Tests
 
     func testCoarsenAgeGroup_earlySuffix_withS() {


### PR DESCRIPTION
## Summary
- **Issue #163**: TSan有効スキーム (`FinalHourglass-TSan`) と CI ワークフロー (`ios-tsan.yml`) を追加。週次スケジュール + スレッド関連ファイル変更時にAnalyticsManagerTestsをTSan付きで実行
- **Issue #164**: FeedbackCategoryテスト（allCases / displayName / icon）を `ReviewManagerTests` から `FeedbackFormViewTests` に集約
- AnalyticsManagerTestsのコメントをTSan CI実行に合わせて更新

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `FeedbackFormViewTests.swift` | テスト3メソッド追加 + コメント更新 |
| `ReviewManagerTests.swift` | FeedbackCategoryテスト3メソッド削除 |
| `AnalyticsManagerTests.swift` | MARKコメント更新 |
| `FinalHourglass-TSan.xcscheme` | 新規（threadSanitizerEnabled=YES） |
| `ios-tsan.yml` | 新規ワークフロー |

## Test plan
- [ ] `FeedbackFormViewTests` の全テストがパスすること
- [ ] `ReviewManagerTests` の全テストがパスすること（FeedbackCategory削除後も既存テスト影響なし）
- [ ] `ios-tsan.yml` の YAML 構文が正しいこと（✅ 検証済み）
- [ ] `FinalHourglass-TSan` スキームでAnalyticsManagerTestsがTSan付きで実行可能なこと
- [ ] CI 全チェック pass

Closes #163
Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * フィードバック機能の検証テストを強化しました

* **チェア**
  * 定期的なテスト自動化ワークフローを導入しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->