### PR TITLE
fix: CodeRabbit #171指摘対応 - 再生中復帰テスト・currentBGMFilenameアサーション追加

### DIFF
--- a/ios-apps/final-hourglass/FinalHourglass/Managers/SoundManager.swift
+++ b/ios-apps/final-hourglass/FinalHourglass/Managers/SoundManager.swift
@@ -378,6 +378,59 @@ class SoundManager: ObservableObject {
         fadeTimer = Timer.scheduledTimer(withTimeInterval: 999, repeats: false) { _ in }
     }
 
+    // swiftlint:disable function_body_length
+    func testHelperSimulateFadingWhilePlaying(currentBGMFilename: String?) {
+        self.currentBGMFilename = currentBGMFilename
+        cancelFadeTimers()
+        fadeTimer = Timer.scheduledTimer(withTimeInterval: 999, repeats: false) { _ in }
+
+        // 最小限の無音WAVデータでbgmPlayerを作成し再生状態にする
+        let sampleRate: UInt32 = 8000
+        let numSamples: UInt32 = 8000
+        let bitsPerSample: UInt16 = 16
+        let numChannels: UInt16 = 1
+        let dataSize = numSamples * UInt32(bitsPerSample / 8) * UInt32(numChannels)
+        var wavData = Data()
+        // RIFF header
+        wavData.append(contentsOf: [0x52, 0x49, 0x46, 0x46]) // "RIFF"
+        var chunkSize = 36 + dataSize
+        wavData.append(Data(bytes: &chunkSize, count: 4))
+        wavData.append(contentsOf: [0x57, 0x41, 0x56, 0x45]) // "WAVE"
+        // fmt sub-chunk
+        wavData.append(contentsOf: [0x66, 0x6D, 0x74, 0x20]) // "fmt "
+        var subchunk1Size: UInt32 = 16
+        wavData.append(Data(bytes: &subchunk1Size, count: 4))
+        var audioFormat: UInt16 = 1 // PCM
+        wavData.append(Data(bytes: &audioFormat, count: 2))
+        var channels = numChannels
+        wavData.append(Data(bytes: &channels, count: 2))
+        var rate = sampleRate
+        wavData.append(Data(bytes: &rate, count: 4))
+        var byteRate = sampleRate * UInt32(numChannels) * UInt32(bitsPerSample / 8)
+        wavData.append(Data(bytes: &byteRate, count: 4))
+        var blockAlign = numChannels * (bitsPerSample / 8)
+        wavData.append(Data(bytes: &blockAlign, count: 2))
+        var bps = bitsPerSample
+        wavData.append(Data(bytes: &bps, count: 2))
+        // data sub-chunk
+        wavData.append(contentsOf: [0x64, 0x61, 0x74, 0x61]) // "data"
+        var dSize = dataSize
+        wavData.append(Data(bytes: &dSize, count: 4))
+        wavData.append(Data(count: Int(dataSize))) // 無音データ
+
+        do {
+            bgmPlayer = try AVAudioPlayer(data: wavData)
+            bgmPlayer?.numberOfLoops = -1
+            bgmPlayer?.volume = bgmVolume
+            bgmPlayer?.prepareToPlay()
+            bgmPlayer?.play()
+            isBGMPlaying = true
+        } catch {
+            print("テスト用音声プレイヤー作成失敗: \(error)")
+        }
+    }
+    // swiftlint:enable function_body_length
+
     func testHelperClearFadeState() {
         cancelFadeTimers()
         stopCurrentBGM()

--- a/ios-apps/final-hourglass/FinalHourglassTests/SoundManagerTests.swift
+++ b/ios-apps/final-hourglass/FinalHourglassTests/SoundManagerTests.swift
@@ -192,6 +192,27 @@ final class SoundManagerTests: XCTestCase {
         XCTAssertFalse(sut.testHelperIsFading, "別BGM切り替えでフェードタイマーがキャンセルされること")
         // Bundle不在のため最終状態はisBGMPlaying = false
         XCTAssertFalse(sut.isBGMPlaying, "Bundle不在時はisBGMPlayingがfalseであること")
+        XCTAssertNil(sut.testHelperCurrentBGMFilename, "旧BGM名がクリアされること")
+
+        sut.testHelperClearFadeState()
+    }
+
+    func testFadingStateSameBGMWhilePlayingResumesBGM() {
+        let sut = SoundManager.shared
+        sut.stopBackgroundMusic()
+
+        // 再生中 + フェード中をシミュレート（同一BGM）
+        sut.testHelperSimulateFadingWhilePlaying(currentBGMFilename: "open-sound.m4a")
+        XCTAssertTrue(sut.testHelperIsFading, "フェードタイマーがセットされていること")
+        XCTAssertTrue(sut.isBGMPlaying, "BGMが再生中であること")
+
+        // 同一BGMで再生要求 → フェードキャンセル & 再生継続（return false分岐）
+        sut.playBackgroundMusic(filename: "open-sound", withExtension: "m4a")
+
+        // フェードキャンセルされ、再生は継続している
+        XCTAssertFalse(sut.testHelperIsFading, "フェードタイマーがキャンセルされること")
+        XCTAssertTrue(sut.isBGMPlaying, "同一BGM復帰で再生が継続すること")
+        XCTAssertEqual(sut.testHelperCurrentBGMFilename, "open-sound.m4a", "BGMファイル名が維持されること")
 
         sut.testHelperClearFadeState()
     }
@@ -208,6 +229,7 @@ final class SoundManagerTests: XCTestCase {
 
         // 別ファイルなので旧BGM停止ルートを通る
         XCTAssertFalse(sut.testHelperIsFading, "同名別拡張子は別ファイルとして扱われフェードがキャンセルされること")
+        XCTAssertNil(sut.testHelperCurrentBGMFilename, "旧BGM名が残らないこと")
 
         sut.testHelperClearFadeState()
     }


### PR DESCRIPTION
## Summary
- **指摘1対応**: `testHelperSimulateFadingWhilePlaying`ヘルパー追加（無音WAVデータで再生中状態をシミュレート）、`testFadingStateSameBGMWhilePlayingResumesBGM`テスト追加で`handleFadingState`の同一BGM復帰分岐（`player.isPlaying == true → return false`）をカバー
- **指摘2対応**: `testFadingStateDifferentBGMStopsOld`と`testSameNameDifferentExtensionTreatedAsDistinct`に`XCTAssertNil(currentBGMFilename)`追加で`stopCurrentBGM()`の効果を検証

## Test plan
- [x] 全21テスト（既存20 + 新規1）パス確認済み
- [x] SwiftLint `function_body_length` を `swiftlint:disable` で対応（`#if DEBUG`内テストヘルパー）
- [x] pre-commit hooks全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * バックグラウンド音楽のフェード処理に関するテストカバレッジを強化しました。音声ファイル切り替え時の状態管理の精度を検証し、オーディオシステムの信頼性を向上させます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->