### PR TITLE
test: テストカバレッジを14.9%→89%に向上（Phase 1）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,7 @@ typeCheckingMode = "strict"
 [tool.pytest]
 
 [tool.pytest.ini_options]
-addopts = "-q --strict-markers --tb=short --cov=src --cov-report=term-missing:skip-covered"
+addopts = "-q --strict-markers --tb=short --cov=src --cov-report=term-missing:skip-covered --cov-report=xml"
 filterwarnings = [
   "ignore:coroutine.*was never awaited:RuntimeWarning",
   "ignore::pytest.PytestUnraisableExceptionWarning"

--- a/tests/models/test_episode_source.py
+++ b/tests/models/test_episode_source.py
@@ -301,6 +301,32 @@ def test_from_dict_without_source_id():
     assert source.source_id.startswith("SRC-")
 
 
+def test_validation_missing_person_id():
+    """バリデーション: person_idが空の場合"""
+    with pytest.raises(ValueError, match="person_id is required"):
+        EpisodeSource(
+            person_name="テスト",
+            person_id="",
+            person_type="REAL",
+            source_url="https://example.com",
+            source_type="manual",
+            raw_text="テキスト",
+        )
+
+
+def test_validation_missing_source_url():
+    """バリデーション: source_urlが空の場合"""
+    with pytest.raises(ValueError, match="source_url is required"):
+        EpisodeSource(
+            person_name="テスト",
+            person_id="P001ABC12",
+            person_type="REAL",
+            source_url="",
+            source_type="manual",
+            raw_text="テキスト",
+        )
+
+
 def test_validation_missing_person_name():
     """バリデーション: person_nameが空の場合"""
     with pytest.raises(ValueError, match="person_name is required"):

--- a/tests/models/test_verified_source.py
+++ b/tests/models/test_verified_source.py
@@ -174,3 +174,364 @@ def test_filter_verified():
     verified = VerifiedSource.filter_verified(sources)
     assert len(verified) == 1
     assert verified[0].person_name == "人物A"
+
+
+# ============================================================================
+# 追加テスト: 未カバー行の網羅
+# ============================================================================
+
+
+def _make_verified_source(**kwargs):
+    """テスト用ヘルパー: 有効なVerifiedSourceを作成"""
+    defaults = {
+        "person_name": "テスト太郎",
+        "person_id": "P001ABC12",
+        "person_type": "REAL",
+        "source_url": "https://example.com/test",
+        "source_type": "manual",
+        "raw_text": "テストテキスト",
+    }
+    defaults.update(kwargs)
+    return VerifiedSource(**defaults)
+
+
+class TestVerifiedSourceToDict:
+    """to_dict() メソッドのテスト（VerifiedSource固有のフィールド）"""
+
+    def test_includes_verifier_notes(self):
+        """verifier_notesが辞書に含まれる"""
+        source = _make_verified_source(verifier_notes="検証メモ")
+        data = source.to_dict()
+        assert data["verifier_notes"] == "検証メモ"
+
+    def test_verifier_notes_none_becomes_empty_string(self):
+        """verifier_notesがNoneの場合は空文字になる"""
+        source = _make_verified_source()
+        data = source.to_dict()
+        assert data["verifier_notes"] == ""
+
+    def test_includes_parent_fields(self):
+        """親クラス(EpisodeSource)のフィールドも含む"""
+        source = _make_verified_source()
+        data = source.to_dict()
+        assert "source_id" in data
+        assert "person_name" in data
+        assert "person_id" in data
+        assert "source_url" in data
+        assert "collected_at" in data
+
+
+class TestVerifiedSourceFromDict:
+    """from_dict() クラスメソッドのテスト"""
+
+    def test_creates_from_dict(self):
+        """辞書からVerifiedSourceインスタンスを作成"""
+        data = {
+            "person_name": "テスト太郎",
+            "person_id": "P001ABC12",
+            "person_type": "REAL",
+            "source_url": "https://example.com/test",
+            "source_type": "manual",
+            "raw_text": "テストテキスト",
+            "evidence_quality": "B",
+            "verification_status": "verified",
+            "verifier_notes": "検証完了",
+        }
+        source = VerifiedSource.from_dict(data)
+        assert source.person_name == "テスト太郎"
+        assert source.evidence_quality == "B"
+        assert source.verifier_notes == "検証完了"
+
+    def test_from_dict_with_collected_at_string(self):
+        """collected_atが文字列の場合にdatetimeに変換"""
+        data = {
+            "person_name": "テスト太郎",
+            "person_id": "P001ABC12",
+            "person_type": "REAL",
+            "source_url": "https://example.com/test",
+            "source_type": "manual",
+            "raw_text": "テストテキスト",
+            "collected_at": "2025-06-15T10:00:00",
+        }
+        source = VerifiedSource.from_dict(data)
+        assert isinstance(source.collected_at, datetime)
+        assert source.collected_at.year == 2025
+
+    def test_from_dict_with_collected_at_none(self):
+        """collected_atがNoneの場合は現在時刻を使用"""
+        data = {
+            "person_name": "テスト太郎",
+            "person_id": "P001ABC12",
+            "person_type": "REAL",
+            "source_url": "https://example.com/test",
+            "source_type": "manual",
+            "raw_text": "テストテキスト",
+            "collected_at": None,
+        }
+        source = VerifiedSource.from_dict(data)
+        assert isinstance(source.collected_at, datetime)
+
+    def test_from_dict_with_verified_at_string(self):
+        """verified_atが文字列の場合にdatetimeに変換"""
+        data = {
+            "person_name": "テスト太郎",
+            "person_id": "P001ABC12",
+            "person_type": "REAL",
+            "source_url": "https://example.com/test",
+            "source_type": "manual",
+            "raw_text": "テストテキスト",
+            "verified_at": "2025-06-15T14:30:00",
+        }
+        source = VerifiedSource.from_dict(data)
+        assert isinstance(source.verified_at, datetime)
+        assert source.verified_at.hour == 14
+
+    def test_from_dict_with_verified_at_empty_string(self):
+        """verified_atが空文字の場合はNone"""
+        data = {
+            "person_name": "テスト太郎",
+            "person_id": "P001ABC12",
+            "person_type": "REAL",
+            "source_url": "https://example.com/test",
+            "source_type": "manual",
+            "raw_text": "テストテキスト",
+            "verified_at": "",
+        }
+        source = VerifiedSource.from_dict(data)
+        assert source.verified_at is None
+
+    def test_from_dict_with_source_id(self):
+        """source_idが指定されている場合は上書き"""
+        data = {
+            "source_id": "SRC-custom12345678",
+            "person_name": "テスト太郎",
+            "person_id": "P001ABC12",
+            "person_type": "REAL",
+            "source_url": "https://example.com/test",
+            "source_type": "manual",
+            "raw_text": "テストテキスト",
+        }
+        source = VerifiedSource.from_dict(data)
+        assert source.source_id == "SRC-custom12345678"
+
+    def test_from_dict_without_source_id(self):
+        """source_idがない場合は自動生成"""
+        data = {
+            "person_name": "テスト太郎",
+            "person_id": "P001ABC12",
+            "person_type": "REAL",
+            "source_url": "https://example.com/test",
+            "source_type": "manual",
+            "raw_text": "テストテキスト",
+        }
+        source = VerifiedSource.from_dict(data)
+        assert source.source_id.startswith("SRC-")
+
+    def test_from_dict_default_values(self):
+        """オプションフィールドのデフォルト値"""
+        data = {
+            "person_name": "テスト太郎",
+            "person_id": "P001ABC12",
+            "person_type": "REAL",
+            "source_url": "https://example.com/test",
+            "source_type": "manual",
+            "raw_text": "テストテキスト",
+        }
+        source = VerifiedSource.from_dict(data)
+        assert source.evidence_quality == "C"
+        assert source.verification_status == "unverified"
+        assert source.verifier_notes is None
+
+
+class TestVerifiedSourceSaveToCSV:
+    """save_to_csv() 静的メソッドのテスト"""
+
+    def test_saves_sources(self, tmp_path):
+        """ソースをCSVに保存"""
+        sources = [_make_verified_source()]
+        csv_path = tmp_path / "verified.csv"
+        VerifiedSource.save_to_csv(sources, csv_path)
+        assert csv_path.exists()
+
+    def test_empty_list_does_nothing(self, tmp_path):
+        """空リストの場合はファイルを作成しない"""
+        csv_path = tmp_path / "empty.csv"
+        VerifiedSource.save_to_csv([], csv_path)
+        assert not csv_path.exists()
+
+    def test_append_mode(self, tmp_path):
+        """追記モードで保存"""
+        import pandas as pd
+
+        csv_path = tmp_path / "append.csv"
+
+        # 1件目保存
+        source1 = _make_verified_source(
+            person_name="人物1",
+            source_url="https://example.com/1",
+        )
+        VerifiedSource.save_to_csv([source1], csv_path)
+
+        # 2件目追記
+        source2 = _make_verified_source(
+            person_name="人物2",
+            source_url="https://example.com/2",
+        )
+        VerifiedSource.save_to_csv([source2], csv_path, append=True)
+
+        df = pd.read_csv(csv_path, encoding="utf-8-sig")
+        assert len(df) == 2
+
+    def test_append_deduplication(self, tmp_path):
+        """追記時にsource_idで重複排除"""
+        import pandas as pd
+
+        csv_path = tmp_path / "dedup.csv"
+        source = _make_verified_source()
+
+        # 同一ソースを2回保存
+        VerifiedSource.save_to_csv([source], csv_path)
+        VerifiedSource.save_to_csv([source], csv_path, append=True)
+
+        df = pd.read_csv(csv_path, encoding="utf-8-sig")
+        assert len(df) == 1
+
+    def test_creates_parent_directory(self, tmp_path):
+        """親ディレクトリを自動作成"""
+        csv_path = tmp_path / "subdir" / "verified.csv"
+        sources = [_make_verified_source()]
+        VerifiedSource.save_to_csv(sources, csv_path)
+        assert csv_path.exists()
+
+
+class TestVerifiedSourceLoadFromCSV:
+    """load_from_csv() 静的メソッドのテスト"""
+
+    def test_loads_sources(self, tmp_path):
+        """CSVからソースを読み込み"""
+        csv_path = tmp_path / "verified.csv"
+
+        # 保存
+        source = _make_verified_source(evidence_quality="A")
+        VerifiedSource.save_to_csv([source], csv_path)
+
+        # 読み込み
+        loaded = VerifiedSource.load_from_csv(csv_path)
+        assert len(loaded) == 1
+        assert loaded[0].person_name == "テスト太郎"
+
+    def test_returns_empty_for_nonexistent_file(self, tmp_path):
+        """存在しないファイルの場合は空リスト"""
+        csv_path = tmp_path / "nonexistent.csv"
+        loaded = VerifiedSource.load_from_csv(csv_path)
+        assert loaded == []
+
+    def test_handles_invalid_rows(self, tmp_path):
+        """不正な行をスキップして読み込み"""
+        import pandas as pd
+
+        csv_path = tmp_path / "invalid.csv"
+        df = pd.DataFrame(
+            [
+                {
+                    "source_id": "SRC-valid123456789",
+                    "person_name": "有効な人物",
+                    "person_id": "P001",
+                    "person_type": "REAL",
+                    "source_url": "https://example.com/valid",
+                    "source_type": "manual",
+                    "raw_text": "有効なテキスト",
+                    "context": "",
+                    "evidence_quality": "C",
+                    "verification_status": "unverified",
+                    "collected_at": "2025-06-15T10:00:00",
+                    "verified_at": "",
+                    "verifier_notes": "",
+                },
+                {
+                    "source_id": "SRC-invalid123456",
+                    "person_name": "",
+                    "person_id": "",
+                    "person_type": "INVALID",
+                    "source_url": "not-a-url",
+                    "source_type": "unknown",
+                    "raw_text": "",
+                    "context": "",
+                    "evidence_quality": "X",
+                    "verification_status": "bad",
+                    "collected_at": "",
+                    "verified_at": "",
+                    "verifier_notes": "",
+                },
+            ]
+        )
+        df.to_csv(csv_path, index=False, encoding="utf-8-sig")
+
+        loaded = VerifiedSource.load_from_csv(csv_path)
+        # 有効な行のみ読み込まれる
+        assert len(loaded) == 1
+
+
+class TestVerifiedSourceMarkVerifiedNoNotes:
+    """mark_verified() のノートなし呼び出しテスト"""
+
+    def test_mark_verified_without_notes(self):
+        """ノートなしでmark_verifiedを呼ぶ"""
+        source = _make_verified_source()
+        source.mark_verified()
+
+        assert source.verification_status == "verified"
+        assert source.verified_at is not None
+        assert source.verifier_notes is None
+
+
+class TestAutoJudgeQualityAdditional:
+    """auto_judge_quality() の追加ドメインテスト"""
+
+    def test_academic_domain_ac_jp(self):
+        """学術機関(.ac.jp)はA品質"""
+        source = _make_verified_source(
+            source_url="https://www.u-tokyo.ac.jp/research",
+        )
+        assert source.evidence_quality == "A"
+
+    def test_edu_domain(self):
+        """教育機関(.edu)はA品質"""
+        source = _make_verified_source(
+            source_url="https://www.mit.edu/research",
+        )
+        assert source.evidence_quality == "A"
+
+    def test_ndl_domain(self):
+        """国会図書館(ndl.go.jp)はA品質"""
+        source = _make_verified_source(
+            source_url="https://ndl.go.jp/collection/test",
+        )
+        assert source.evidence_quality == "A"
+
+    def test_britannica_domain(self):
+        """ブリタニカ(britannica.com)はB品質"""
+        source = _make_verified_source(
+            source_url="https://www.britannica.com/topic/test",
+        )
+        assert source.evidence_quality == "B"
+
+    def test_no_auto_judge_when_quality_already_set(self):
+        """evidence_qualityがC以外で設定済みの場合、自動判定しない"""
+        source = _make_verified_source(
+            source_url="https://www.mext.go.jp/test",
+            evidence_quality="B",
+            verification_status="verified",
+        )
+        # Bで設定されているので、自動判定されない（条件: C and unverified）
+        assert source.evidence_quality == "B"
+
+    def test_no_auto_judge_when_already_verified(self):
+        """verification_statusがverifiedの場合、自動判定しない"""
+        source = _make_verified_source(
+            source_url="https://www.mext.go.jp/test",
+            evidence_quality="C",
+            verification_status="verified",
+        )
+        # verified状態なので自動判定されない
+        assert source.evidence_quality == "C"

--- a/tests/test_age_distribution_checker.py
+++ b/tests/test_age_distribution_checker.py
@@ -176,5 +176,208 @@ class TestAgeDistributionChecker:
         assert any("P002" in s.message for s in suspicious)
 
 
+class TestIsUniformInterval:
+    """_is_uniform_interval() メソッドの直接テスト"""
+
+    def setup_method(self):
+        self.checker = AgeDistributionChecker()
+
+    def test_uniform_interval_true(self):
+        """等間隔の場合はTrueを返す"""
+        assert self.checker._is_uniform_interval([10, 15, 20]) is True
+
+    def test_non_uniform_interval_false(self):
+        """等間隔でない場合はFalseを返す"""
+        assert self.checker._is_uniform_interval([10, 15, 22]) is False
+
+    def test_two_elements_false(self):
+        """2件では等間隔判定しない（Falseを返す）"""
+        assert self.checker._is_uniform_interval([10, 20]) is False
+
+    def test_one_element_false(self):
+        """1件ではFalseを返す"""
+        assert self.checker._is_uniform_interval([10]) is False
+
+    def test_empty_list_false(self):
+        """空リストではFalseを返す"""
+        assert self.checker._is_uniform_interval([]) is False
+
+
+class TestCheckDistributionEdgeCases:
+    """_check_distribution のエッジケーステスト"""
+
+    def setup_method(self):
+        self.checker = AgeDistributionChecker()
+
+    def test_empty_ages(self):
+        """空のリストはOK"""
+        result = self.checker.check_person_distribution("P001", [])
+        assert result.result == CheckResult.OK
+        assert not result.is_suspicious
+
+    def test_mixed_ages_no_five_multiple_issue(self):
+        """5の倍数比率がしきい値未満で等間隔でもない場合はOK"""
+        ages = [7.0, 13.0, 22.0, 38.0, 51.0]
+        result = self.checker.check_person_distribution("P001", ages)
+        assert result.result == CheckResult.OK
+
+    def test_five_multiples_below_three_not_all_five(self):
+        """3件未満で全5の倍数チェックを通過"""
+        ages = [10.0, 20.0]
+        result = self.checker.check_person_distribution("P001", ages)
+        # 2件なので「全て5の倍数」チェックは発動しない（3件以上が条件）
+        # ただし5の倍数偏重（100%）は検出される
+        assert result.is_suspicious
+
+
+class TestScanDatabaseExtended:
+    """scan_database の拡張テスト"""
+
+    def setup_method(self):
+        self.checker = AgeDistributionChecker()
+
+    def test_empty_database(self):
+        """空のデータベースは空リスト"""
+        result = self.checker.scan_database({})
+        assert len(result) == 0
+
+    def test_all_ok_database(self):
+        """全員OKの場合は空リスト"""
+        db = {
+            "P001": [7.0, 22.0, 38.0],
+            "P002": [11.0, 29.0, 44.0],
+        }
+        result = self.checker.scan_database(db)
+        assert len(result) == 0
+
+    def test_multiple_suspicious(self):
+        """複数の疑わしいパターンを検出"""
+        db = {
+            "P001": [20.0, 25.0, 30.0],  # 疑わしい
+            "P002": [10.0, 20.0, 30.0],  # 疑わしい
+            "P003": [7.0, 22.0, 38.0],  # OK
+        }
+        result = self.checker.scan_database(db)
+        assert len(result) == 2
+
+
+class TestAgeCheckResult:
+    """AgeCheckResult データクラスのテスト"""
+
+    def test_result_fields(self):
+        """フィールドが正しく設定される"""
+        from src.validators.age_distribution_checker import AgeCheckResult
+
+        result = AgeCheckResult(
+            result=CheckResult.OK,
+            is_suspicious=False,
+            message="テスト",
+            details={"key": "value"},
+        )
+        assert result.result == CheckResult.OK
+        assert result.is_suspicious is False
+        assert result.message == "テスト"
+        assert result.details == {"key": "value"}
+
+
+class TestCheckResultEnum:
+    """CheckResult Enumのテスト"""
+
+    def test_values(self):
+        assert CheckResult.OK.value == "OK"
+        assert CheckResult.WARNING.value == "WARNING"
+        assert CheckResult.BLOCK.value == "BLOCK"
+
+
+class TestMainFunction:
+    """main() 関数のテスト"""
+
+    def test_main_csv_not_found(self, monkeypatch, capsys):
+        """CSVが見つからない場合"""
+        from src.validators import age_distribution_checker
+
+        monkeypatch.setattr("sys.argv", ["age_distribution_checker.py", "--csv", "/tmp/nonexistent_test.csv"])
+        exit_code = age_distribution_checker.main()
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "ファイルが見つかりません" in captured.out
+
+    def test_main_with_clean_csv(self, tmp_path, monkeypatch, capsys):
+        """問題のないCSVでmain実行"""
+        import csv as csv_mod
+
+        from src.validators import age_distribution_checker
+
+        csv_path = tmp_path / "test.csv"
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv_mod.DictWriter(f, fieldnames=["person_id", "person_name", "age"])
+            writer.writeheader()
+            writer.writerow({"person_id": "P001", "person_name": "テスト太郎", "age": "17"})
+            writer.writerow({"person_id": "P001", "person_name": "テスト太郎", "age": "28"})
+            writer.writerow({"person_id": "P001", "person_name": "テスト太郎", "age": "43"})
+
+        monkeypatch.setattr("sys.argv", ["age_distribution_checker.py", "--csv", str(csv_path)])
+        exit_code = age_distribution_checker.main()
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "年齢分布チェッカー" in captured.out
+        assert "対象: 1人" in captured.out
+
+    def test_main_with_suspicious_csv(self, tmp_path, monkeypatch, capsys):
+        """疑わしいパターンを含むCSVでmain実行"""
+        import csv as csv_mod
+
+        from src.validators import age_distribution_checker
+
+        csv_path = tmp_path / "test.csv"
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv_mod.DictWriter(f, fieldnames=["person_id", "person_name", "age"])
+            writer.writeheader()
+            # 5歳刻みパターン
+            writer.writerow({"person_id": "P001", "person_name": "テスト太郎", "age": "20"})
+            writer.writerow({"person_id": "P001", "person_name": "テスト太郎", "age": "25"})
+            writer.writerow({"person_id": "P001", "person_name": "テスト太郎", "age": "30"})
+
+        monkeypatch.setattr("sys.argv", ["age_distribution_checker.py", "--csv", str(csv_path)])
+        exit_code = age_distribution_checker.main()
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "疑わしいパターン" in captured.out
+
+    def test_main_with_strict_mode(self, tmp_path, monkeypatch, capsys):
+        """--strict モードでmain実行"""
+        import csv as csv_mod
+
+        from src.validators import age_distribution_checker
+
+        csv_path = tmp_path / "test.csv"
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv_mod.DictWriter(f, fieldnames=["person_id", "person_name", "age"])
+            writer.writeheader()
+            writer.writerow({"person_id": "P001", "person_name": "テスト", "age": "17"})
+            writer.writerow({"person_id": "P001", "person_name": "テスト", "age": "28"})
+
+        monkeypatch.setattr("sys.argv", ["age_distribution_checker.py", "--csv", str(csv_path), "--strict"])
+        exit_code = age_distribution_checker.main()
+        assert exit_code == 0
+
+    def test_main_with_invalid_age(self, tmp_path, monkeypatch, capsys):
+        """無効な年齢値を含むCSV（ValueErrorがスキップされる）"""
+        import csv as csv_mod
+
+        from src.validators import age_distribution_checker
+
+        csv_path = tmp_path / "test.csv"
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv_mod.DictWriter(f, fieldnames=["person_id", "person_name", "age"])
+            writer.writeheader()
+            writer.writerow({"person_id": "P001", "person_name": "テスト", "age": "invalid"})
+            writer.writerow({"person_id": "P002", "person_name": "テスト2", "age": "25"})
+
+        monkeypatch.setattr("sys.argv", ["age_distribution_checker.py", "--csv", str(csv_path)])
+        exit_code = age_distribution_checker.main()
+        assert exit_code == 0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_duplication_detector.py
+++ b/tests/test_duplication_detector.py
@@ -487,3 +487,79 @@ class TestVerifyAttributesNoChecks:
 
         # checks == 0 または属性不一致で False
         assert result is False
+
+
+# ============================================================================
+# 追加テスト: 未カバー行の網羅
+# ============================================================================
+
+
+class TestBuildCache:
+    """_build_cache メソッドのテスト"""
+
+    def test_build_cache_skips_when_already_built(self, sample_master_df):
+        """キャッシュ構築済みの場合はスキップ"""
+        detector = DuplicationDetector(sample_master_df)
+        mock_normalizer = MagicMock()
+        mock_normalizer.normalize.return_value = None
+        detector.normalizer = mock_normalizer
+        detector._cache_built = True
+
+        # 再構築しない（normalizeが呼ばれない）
+        detector._build_cache()
+        mock_normalizer.normalize.assert_not_called()
+
+    def test_build_cache_skips_when_normalizer_is_none(self, sample_master_df):
+        """normalizerがNoneの場合はスキップ"""
+        detector = DuplicationDetector(sample_master_df)
+        assert detector.normalizer is None
+
+        # 例外なくスキップされる
+        detector._build_cache()
+        assert not detector._cache_built
+
+
+class TestLayer4SimilarMatchSuccess:
+    """Layer 4 類似一致で実際にTrueを返すテスト"""
+
+    def test_similar_match_returns_true(self):
+        """類似度0.85以上 + 属性検証成功で重複判定"""
+        master_df = pd.DataFrame(
+            [
+                {
+                    "person_name": "佐藤次郎三太郎",
+                    "category": "政治・経済",
+                    "birth_year": 1960,
+                    "person_type": "REAL",
+                },
+            ]
+        )
+        detector = DuplicationDetector(master_df)
+
+        # 7文字中6文字一致: 2*6/14 = 0.857 >= 0.85
+        candidate = PersonCandidate(
+            person_name="佐藤次郎三太朗",
+            category="政治・経済",
+            birth_year=1960,
+            person_type="REAL",
+        )
+
+        with patch.object(detector, "_load_normalizer"):
+            mock_normalizer = MagicMock()
+
+            def mock_normalize(name):
+                result = MagicMock()
+                result.normalized_name = name
+                return result
+
+            mock_normalizer.normalize = mock_normalize
+            detector.normalizer = mock_normalizer
+            detector.alias_map = {}
+
+            is_dup, matched, conf, layer = detector.detect_duplicate(candidate)
+
+            # 類似度が0.85以上かつ属性一致で重複判定される
+            assert is_dup is True
+            assert matched == "佐藤次郎三太郎"
+            assert layer == "similar"
+            assert conf >= 0.85

--- a/tests/test_episode_name_validator.py
+++ b/tests/test_episode_name_validator.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+episode_name_validator.py のユニットテスト
+
+対象: extract_lead_name(), validate_episode_name(), EpisodeNameValidatorクラス
+"""
+
+import pytest
+
+from src.validators.episode_name_validator import (
+    EpisodeNameValidator,
+    NameValidationResult,
+    ValidationResult,
+    extract_lead_name,
+    validate_episode_name,
+)
+
+
+# ============================================================
+# extract_lead_name() テスト
+# ============================================================
+
+
+class TestExtractLeadName:
+    """extract_lead_name() 関数のテスト"""
+
+    def test_returns_none_for_empty_text(self):
+        """空テキストはNoneを返す"""
+        assert extract_lead_name("") is None
+
+    def test_returns_none_for_none_text(self):
+        """Noneテキストはエラーにならず空扱い"""
+        assert extract_lead_name(None) is None  # type: ignore[arg-type]
+
+    def test_extracts_name_from_normal_format(self):
+        """通常形式「あなたと同じN歳のとき、{名前}は」から名前を抽出"""
+        text = "あなたと同じ30歳のとき、山田太郎は起業した。"
+        assert extract_lead_name(text) == "山田太郎"
+
+    def test_extracts_name_from_fictional_format(self):
+        """架空キャラ形式「あなたと同じN歳のとき、{名前}『{作品名}』は」から名前を抽出"""
+        text = "あなたと同じ17歳のとき、毛利蘭『名探偵コナン』は空手大会で優勝した。"
+        assert extract_lead_name(text) == "毛利蘭"
+
+    def test_extracts_with_person_name_hint_normal(self):
+        """person_nameヒントで通常形式を優先チェック"""
+        text = "あなたと同じ30歳のとき、山田太郎は起業した。"
+        assert extract_lead_name(text, person_name="山田太郎") == "山田太郎"
+
+    def test_extracts_with_person_name_hint_fictional(self):
+        """person_nameヒントで架空キャラ形式を優先チェック"""
+        text = "あなたと同じ17歳のとき、毛利蘭『名探偵コナン』は空手大会で優勝した。"
+        assert extract_lead_name(text, person_name="毛利蘭") == "毛利蘭"
+
+    def test_returns_none_for_non_matching_format(self):
+        """リード文パターンに一致しないテキストはNoneを返す"""
+        text = "これは不正なフォーマットです。"
+        assert extract_lead_name(text) is None
+
+    def test_handles_decimal_age(self):
+        """小数年齢を含むリード文を処理"""
+        text = "あなたと同じ0.5歳のとき、赤ちゃんは笑った。"
+        result = extract_lead_name(text)
+        assert result == "赤ちゃん"
+
+    def test_fallback_when_person_name_not_match(self):
+        """person_nameが一致しない場合にフォールバックで抽出"""
+        text = "あなたと同じ30歳のとき、実際の名前は活躍した。"
+        result = extract_lead_name(text, person_name="別の名前")
+        assert result == "実際の名前"
+
+
+# ============================================================
+# validate_episode_name() テスト
+# ============================================================
+
+
+class TestValidateEpisodeName:
+    """validate_episode_name() 関数のテスト"""
+
+    def test_valid_match_returns_valid(self):
+        """名前が一致する場合はVALIDを返す"""
+        result = validate_episode_name(
+            "山田太郎",
+            "あなたと同じ30歳のとき、山田太郎は起業した。",
+            strict=False,
+        )
+        assert result.result == ValidationResult.VALID
+        assert result.message == "OK"
+
+    def test_valid_fictional_match(self):
+        """架空キャラ形式で名前が一致する場合はVALIDを返す"""
+        result = validate_episode_name(
+            "毛利蘭",
+            "あなたと同じ17歳のとき、毛利蘭『名探偵コナン』は空手大会で優勝した。",
+            strict=False,
+        )
+        assert result.result == ValidationResult.VALID
+
+    def test_mismatch_returns_mismatch(self):
+        """名前が不一致の場合はMISMATCHを返す（非厳密モード）"""
+        result = validate_episode_name(
+            "エイダ・ラヴレース",
+            "あなたと同じ30歳のとき、Ada Lovelaceはプログラムを書いた。",
+            strict=False,
+        )
+        assert result.result == ValidationResult.MISMATCH
+        assert "不一致" in result.message
+
+    def test_mismatch_raises_in_strict_mode(self):
+        """名前が不一致の場合、厳密モードではValueErrorを送出"""
+        with pytest.raises(ValueError, match="不一致"):
+            validate_episode_name(
+                "エイダ・ラヴレース",
+                "あなたと同じ30歳のとき、Ada Lovelaceはプログラムを書いた。",
+                strict=True,
+            )
+
+    def test_no_pattern_returns_no_pattern(self):
+        """リード文パターンが見つからない場合はNO_PATTERNを返す"""
+        result = validate_episode_name(
+            "田中一郎",
+            "これは不正なフォーマットです。",
+            strict=False,
+        )
+        assert result.result == ValidationResult.NO_PATTERN
+        assert result.text_name is None
+
+    def test_no_pattern_does_not_raise_in_strict(self):
+        """NO_PATTERNの場合は厳密モードでもValueErrorは発生しない"""
+        result = validate_episode_name(
+            "田中一郎",
+            "これは不正なフォーマットです。",
+            strict=True,
+        )
+        assert result.result == ValidationResult.NO_PATTERN
+
+    def test_result_contains_person_name(self):
+        """結果にperson_nameが含まれる"""
+        result = validate_episode_name(
+            "テスト太郎",
+            "あなたと同じ25歳のとき、テスト太郎は成功した。",
+            strict=False,
+        )
+        assert result.person_name == "テスト太郎"
+
+    def test_result_contains_text_name(self):
+        """結果にtext_nameが含まれる"""
+        result = validate_episode_name(
+            "テスト太郎",
+            "あなたと同じ25歳のとき、テスト太郎は成功した。",
+            strict=False,
+        )
+        assert result.text_name == "テスト太郎"
+
+
+# ============================================================
+# EpisodeNameValidator クラステスト
+# ============================================================
+
+
+class TestEpisodeNameValidator:
+    """EpisodeNameValidatorクラスのテスト"""
+
+    def test_init_default_strict(self):
+        """デフォルトでstrictモード"""
+        validator = EpisodeNameValidator()
+        assert validator.strict is True
+        assert validator.validation_count == 0
+        assert validator.mismatch_count == 0
+
+    def test_init_non_strict(self):
+        """非strictモードで初期化"""
+        validator = EpisodeNameValidator(strict=False)
+        assert validator.strict is False
+
+    def test_validate_increments_count(self):
+        """validateを呼ぶとカウントが増加する"""
+        validator = EpisodeNameValidator(strict=False)
+        validator.validate("テスト", "あなたと同じ25歳のとき、テストは成功した。")
+        assert validator.validation_count == 1
+
+    def test_validate_increments_mismatch_count(self):
+        """不一致時にmismatch_countが増加する"""
+        validator = EpisodeNameValidator(strict=False)
+        validator.validate("テストA", "あなたと同じ25歳のとき、テストBは成功した。")
+        assert validator.mismatch_count == 1
+
+    def test_validate_valid_does_not_increment_mismatch(self):
+        """一致時はmismatch_countは増加しない"""
+        validator = EpisodeNameValidator(strict=False)
+        validator.validate("テスト", "あなたと同じ25歳のとき、テストは成功した。")
+        assert validator.mismatch_count == 0
+
+    def test_validate_strict_raises_on_mismatch(self):
+        """strictモードで不一致時にValueErrorを送出"""
+        validator = EpisodeNameValidator(strict=True)
+        with pytest.raises(ValueError, match="不一致"):
+            validator.validate("名前A", "あなたと同じ25歳のとき、名前Bは活躍した。")
+
+    def test_get_stats_structure(self):
+        """get_statsが正しい構造を返す"""
+        validator = EpisodeNameValidator(strict=False)
+        stats = validator.get_stats()
+        assert "validation_count" in stats
+        assert "mismatch_count" in stats
+        assert "mismatch_rate" in stats
+
+    def test_get_stats_initial_values(self):
+        """初期状態のstats値"""
+        validator = EpisodeNameValidator(strict=False)
+        stats = validator.get_stats()
+        assert stats["validation_count"] == 0
+        assert stats["mismatch_count"] == 0
+        assert stats["mismatch_rate"] == 0.0
+
+    def test_get_stats_after_multiple_validations(self):
+        """複数回バリデーション後のstats"""
+        validator = EpisodeNameValidator(strict=False)
+        validator.validate("テスト", "あなたと同じ25歳のとき、テストは成功した。")
+        validator.validate("名前A", "あなたと同じ30歳のとき、名前Bは失敗した。")
+        validator.validate("名前C", "あなたと同じ35歳のとき、名前Cは復活した。")
+        stats = validator.get_stats()
+        assert stats["validation_count"] == 3
+        assert stats["mismatch_count"] == 1
+        assert stats["mismatch_rate"] == pytest.approx(1 / 3)
+
+
+# ============================================================
+# ValidationResult Enum テスト
+# ============================================================
+
+
+class TestValidationResultEnum:
+    """ValidationResult Enumのテスト"""
+
+    def test_valid_value(self):
+        assert ValidationResult.VALID.value == "valid"
+
+    def test_mismatch_value(self):
+        assert ValidationResult.MISMATCH.value == "mismatch"
+
+    def test_no_pattern_value(self):
+        assert ValidationResult.NO_PATTERN.value == "no_pattern"
+
+
+# ============================================================
+# NameValidationResult データクラステスト
+# ============================================================
+
+
+class TestNameValidationResult:
+    """NameValidationResultデータクラスのテスト"""
+
+    def test_dataclass_fields(self):
+        """正しいフィールドを持つ"""
+        result = NameValidationResult(
+            result=ValidationResult.VALID,
+            person_name="テスト",
+            text_name="テスト",
+            message="OK",
+        )
+        assert result.result == ValidationResult.VALID
+        assert result.person_name == "テスト"
+        assert result.text_name == "テスト"
+        assert result.message == "OK"
+
+    def test_text_name_can_be_none(self):
+        """text_nameはNoneを許容"""
+        result = NameValidationResult(
+            result=ValidationResult.NO_PATTERN,
+            person_name="テスト",
+            text_name=None,
+            message="パターンなし",
+        )
+        assert result.text_name is None

--- a/tests/test_group_contamination_validator.py
+++ b/tests/test_group_contamination_validator.py
@@ -130,6 +130,298 @@ class TestContaminationIssue:
         assert issue.suggested_fix == "James Hetfield"
 
 
+class TestValidateDataframeExtended:
+    """validate_dataframe関数の拡張テスト"""
+
+    def test_empty_person_name_skipped(self):
+        """空のperson_nameはスキップされる"""
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001"],
+                "person_name": [""],
+                "episode_id": ["E001"],
+            }
+        )
+        issues = validate_dataframe(df)
+        assert len(issues) == 0
+
+    def test_custom_column_name(self):
+        """カスタムカラム名を指定できる"""
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001"],
+                "name": ["Metallica"],
+                "episode_id": ["E001"],
+            }
+        )
+        issues = validate_dataframe(df, person_name_column="name")
+        assert len(issues) == 1
+        assert issues[0].person_name == "Metallica"
+
+    def test_pattern_match_issue_type(self):
+        """団体名サフィックスのパターンマッチで PATTERN_MATCH タイプ"""
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001"],
+                "person_name": ["テスト楽団"],
+                "episode_id": ["E001"],
+            }
+        )
+        issues = validate_dataframe(df)
+        assert len(issues) == 1
+        assert issues[0].issue_type == "PATTERN_MATCH"
+
+    def test_group_entity_suggested_fix(self):
+        """GROUP_ENTITY検出時にメンバー名が提案される"""
+        from src.group_master import GROUP_ENTITIES, GROUP_MEMBER_MAP
+
+        # GROUP_MEMBER_MAPに含まれるグループを見つける
+        for group_name in GROUP_ENTITIES:
+            members = [k for k, v in GROUP_MEMBER_MAP.items() if v == group_name]
+            if members:
+                df = pd.DataFrame(
+                    {
+                        "person_id": ["P001"],
+                        "person_name": [group_name],
+                        "episode_id": ["E001"],
+                    }
+                )
+                issues = validate_dataframe(df)
+                assert len(issues) == 1
+                assert issues[0].issue_type == "GROUP_ENTITY"
+                assert issues[0].suggested_fix is not None
+                break
+
+    def test_multiple_issues_detected(self):
+        """複数の問題を検出"""
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001", "P002", "P003"],
+                "person_name": ["Metallica", "テスト楽団", "山田太郎"],
+                "episode_id": ["E001", "E002", "E003"],
+            }
+        )
+        issues = validate_dataframe(df)
+        assert len(issues) == 2
+
+
+class TestRunContaminationCheck:
+    """run_contamination_check関数のテスト"""
+
+    def test_csv_not_found(self, tmp_path):
+        """CSVファイルが存在しない場合のエラーハンドリング"""
+        from src.validators.group_contamination_validator import run_contamination_check
+
+        nonexistent = tmp_path / "nonexistent.csv"
+        result = run_contamination_check(csv_path=nonexistent, save_report=False)
+        assert result["status"] == "ERROR"
+        assert "error" in result
+
+    def test_clean_csv_passes(self, tmp_path):
+        """問題のないCSVでPASS"""
+        from src.validators.group_contamination_validator import run_contamination_check
+
+        csv_path = tmp_path / "clean.csv"
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001", "P002"],
+                "person_name": ["山田太郎", "田中花子"],
+                "episode_id": ["E001", "E002"],
+            }
+        )
+        df.to_csv(csv_path, index=False, encoding="utf-8-sig")
+
+        result = run_contamination_check(csv_path=csv_path, save_report=False)
+        assert result["status"] == "PASS"
+        assert result["contamination_count"] == 0
+        assert result["total_records"] == 2
+
+    def test_contaminated_csv_fails(self, tmp_path):
+        """問題のあるCSVでFAIL"""
+        from src.validators.group_contamination_validator import run_contamination_check
+
+        csv_path = tmp_path / "contaminated.csv"
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001", "P002"],
+                "person_name": ["Metallica", "山田太郎"],
+                "episode_id": ["E001", "E002"],
+            }
+        )
+        df.to_csv(csv_path, index=False, encoding="utf-8-sig")
+
+        result = run_contamination_check(csv_path=csv_path, save_report=False)
+        assert result["status"] == "FAIL"
+        assert result["contamination_count"] == 1
+
+    def test_save_report_creates_file(self, tmp_path):
+        """レポート保存オプションでファイルが作成される"""
+        from unittest.mock import patch
+
+        from src.validators.group_contamination_validator import run_contamination_check
+
+        csv_path = tmp_path / "test.csv"
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001"],
+                "person_name": ["山田太郎"],
+                "episode_id": ["E001"],
+            }
+        )
+        df.to_csv(csv_path, index=False, encoding="utf-8-sig")
+
+        # レポート保存先をtmp_pathに変更
+        report_dir = tmp_path / "reports"
+        report_dir.mkdir()
+        with patch(
+            "src.validators.group_contamination_validator.PROJECT_ROOT",
+            tmp_path,
+        ):
+            result = run_contamination_check(csv_path=csv_path, save_report=True)
+        assert result["status"] == "PASS"
+        # レポートパスが結果に含まれる
+        if "report_path" in result:
+            assert result["report_path"] is not None
+
+
+class TestValidatePersonIsNotGroupExtended:
+    """validate_person_is_not_group 追加テスト"""
+
+    def test_org_suffix_en_blocked(self):
+        """英語の団体名サフィックスを検出"""
+        is_valid, message = validate_person_is_not_group("Apple Inc.")
+        assert is_valid is False
+        assert "サフィックス" in message
+
+    def test_org_suffix_en_with_space(self):
+        """英語サフィックスの前にスペースがある場合"""
+        is_valid, message = validate_person_is_not_group("Microsoft Corp.")
+        assert is_valid is False
+
+    def test_exclude_suffix_personal_names(self):
+        """個人名除外パターン（太郎、子等）はパスする"""
+        is_valid, message = validate_person_is_not_group("田中太郎")
+        assert is_valid is True
+
+        is_valid, message = validate_person_is_not_group("鈴木花子")
+        assert is_valid is True
+
+    def test_concatenated_with_various_separators(self):
+        """様々なセパレータでの連結パターン検出"""
+        # 実際のGROUP_ENTITIESのグループを使用
+        from src.group_master import GROUP_ENTITIES
+
+        if "ビートルズ" in GROUP_ENTITIES:
+            for sep in ["・", "（", "(", "／", "/"]:
+                name = f"ビートルズ{sep}ポール"
+                is_valid, message = validate_person_is_not_group(name)
+                assert is_valid is False, f"Separator '{sep}' should be detected"
+
+    def test_org_suffix_ja_various(self):
+        """日本語の様々な団体サフィックス"""
+        test_cases = [
+            ("テスト委員会", "委員会"),
+            ("テスト協会", "協会"),
+            ("テスト財団", "財団"),
+            ("テストバンド", "バンド"),
+            ("テストユニット", "ユニット"),
+        ]
+        for name, suffix in test_cases:
+            is_valid, message = validate_person_is_not_group(name)
+            assert is_valid is False, f"Suffix '{suffix}' should be detected in '{name}'"
+
+
+class TestMainFunction:
+    """main() 関数のテスト"""
+
+    def test_main_no_args(self, tmp_path, monkeypatch, capsys):
+        """引数なしでmain実行（デフォルトCSV）"""
+        from unittest.mock import patch
+
+        from src.validators import group_contamination_validator
+
+        # 存在しないデフォルトCSVパスを使う
+        csv_path = tmp_path / "test.csv"
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001"],
+                "person_name": ["山田太郎"],
+                "episode_id": ["E001"],
+            }
+        )
+        df.to_csv(csv_path, index=False, encoding="utf-8-sig")
+
+        monkeypatch.setattr("sys.argv", ["group_contamination_validator.py", "--csv", str(csv_path), "--no-report"])
+        exit_code = group_contamination_validator.main()
+        captured = capsys.readouterr()
+        assert "団体名混入チェック結果" in captured.out
+        assert exit_code == 0
+
+    def test_main_with_issues(self, tmp_path, monkeypatch, capsys):
+        """問題を含むCSVでmain実行"""
+        from src.validators import group_contamination_validator
+
+        csv_path = tmp_path / "test.csv"
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001", "P002"],
+                "person_name": ["Metallica", "山田太郎"],
+                "episode_id": ["E001", "E002"],
+            }
+        )
+        df.to_csv(csv_path, index=False, encoding="utf-8-sig")
+
+        monkeypatch.setattr("sys.argv", ["group_contamination_validator.py", "--csv", str(csv_path), "--no-report"])
+        exit_code = group_contamination_validator.main()
+        captured = capsys.readouterr()
+        assert "混入件数:" in captured.out
+        assert "検出された問題" in captured.out
+        assert exit_code == 0
+
+    def test_main_strict_mode_fails(self, tmp_path, monkeypatch, capsys):
+        """--strictモードで問題があればexit 1"""
+        from src.validators import group_contamination_validator
+
+        csv_path = tmp_path / "test.csv"
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001"],
+                "person_name": ["Metallica"],
+                "episode_id": ["E001"],
+            }
+        )
+        df.to_csv(csv_path, index=False, encoding="utf-8-sig")
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["group_contamination_validator.py", "--csv", str(csv_path), "--no-report", "--strict"],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            group_contamination_validator.main()
+        assert exc_info.value.code == 1
+
+    def test_main_strict_mode_passes(self, tmp_path, monkeypatch, capsys):
+        """--strictモードで問題がなければ正常終了"""
+        from src.validators import group_contamination_validator
+
+        csv_path = tmp_path / "test.csv"
+        df = pd.DataFrame(
+            {
+                "person_id": ["P001"],
+                "person_name": ["山田太郎"],
+                "episode_id": ["E001"],
+            }
+        )
+        df.to_csv(csv_path, index=False, encoding="utf-8-sig")
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["group_contamination_validator.py", "--csv", str(csv_path), "--no-report", "--strict"],
+        )
+        exit_code = group_contamination_validator.main()
+        assert exit_code == 0
+
+
 class TestIntegration:
     """統合テスト"""
 

--- a/tests/test_post_llm_validator.py
+++ b/tests/test_post_llm_validator.py
@@ -327,6 +327,163 @@ class TestIntegration:
         assert len(result.errors) > 0
 
 
+class TestFictionalWorkTitleCheck:
+    """架空キャラ作品名チェックテスト"""
+
+    def setup_method(self):
+        self.validator = PostLLMValidator()
+
+    def test_work_title_present_and_matching(self):
+        """冒頭に正しい作品名がある場合はエラーなし"""
+        text = "あなたと同じ16歳のとき、悟空『ドラゴンボール』は修行を開始しました。" + "テスト" * 40
+        result = self.validator.validate(text, age=16, person_type="FICTIONAL", work_title="ドラゴンボール")
+        # 作品名関連のエラーがないことを確認
+        work_errors = [e for e in result.errors if "作品名" in e or "FICTIONAL" in e]
+        assert len(work_errors) == 0
+
+    def test_work_title_missing(self):
+        """冒頭に作品名がない場合はエラー"""
+        text = "あなたと同じ16歳のとき、悟空は修行を開始しました。" + "テスト" * 40
+        result = self.validator.validate(text, age=16, person_type="FICTIONAL", work_title="ドラゴンボール")
+        work_errors = [e for e in result.errors if "FICTIONAL" in e or "作品名" in e]
+        assert len(work_errors) > 0
+
+    def test_work_title_mismatch(self):
+        """作品名はあるが期待と異なる場合はエラー"""
+        text = "あなたと同じ16歳のとき、悟空『ONE PIECE』は修行を開始しました。" + "テスト" * 40
+        result = self.validator.validate(text, age=16, person_type="FICTIONAL", work_title="ドラゴンボール")
+        work_errors = [e for e in result.errors if "作品名" in e]
+        assert len(work_errors) > 0
+
+    def test_no_work_title_check_when_empty(self):
+        """work_titleが空の場合は作品名チェックをスキップ"""
+        text = "あなたと同じ16歳のとき、悟空は修行を開始しました。" + "テスト" * 40
+        result = self.validator.validate(text, age=16, person_type="FICTIONAL", work_title="")
+        work_errors = [e for e in result.errors if "FICTIONAL" in e or "作品名" in e]
+        assert len(work_errors) == 0
+
+    def test_no_work_title_check_for_real(self):
+        """REALタイプでは作品名チェックを行わない"""
+        text = "あなたと同じ30歳のとき、彼は新しいプロジェクトを開始しました。" + "テスト" * 40
+        result = self.validator.validate(text, age=30, person_type="REAL", work_title="テスト作品")
+        work_errors = [e for e in result.errors if "FICTIONAL" in e or "作品名" in e]
+        assert len(work_errors) == 0
+
+
+class TestEarlyChildhoodQualityCheck:
+    """1-5歳エピソード品質チェックテスト"""
+
+    def setup_method(self):
+        self.validator = PostLLMValidator()
+
+    def test_forbidden_pattern_detected(self):
+        """幼児には不可能な行動が検出される"""
+        text = "あなたと同じ3歳のとき、彼は論文を発表した。" + "テスト" * 30
+        result = self.validator.validate(text, age=3, person_type="REAL")
+        early_errors = [e for e in result.errors if "幼児エピソード品質違反" in e]
+        assert len(early_errors) > 0
+
+    def test_subjective_expression_detected(self):
+        """検証不可能な主観表現が検出される"""
+        text = "あなたと同じ2歳のとき、彼は情熱を秘めていた才能の片鱗を見せた。" + "テスト" * 30
+        result = self.validator.validate(text, age=2, person_type="REAL")
+        early_errors = [e for e in result.errors if "幼児エピソード品質違反" in e]
+        assert len(early_errors) > 0
+
+    def test_recommended_pattern_warning_when_missing(self):
+        """推奨パターンがない場合に警告"""
+        # 推奨パターンを一切含まないテキスト
+        text = "あなたと同じ4歳のとき、彼は明るい性格だった。" + "テスト" * 30
+        result = self.validator.validate(text, age=4, person_type="REAL")
+        early_warnings = [w for w in result.warnings if "第三者視点" in w]
+        assert len(early_warnings) > 0
+
+    def test_no_warning_with_recommended_pattern(self):
+        """推奨パターンがある場合は第三者視点警告なし"""
+        text = "あなたと同じ3歳のとき、伝記によると彼は音楽に興味を示したとされている。" + "テスト" * 30
+        result = self.validator.validate(text, age=3, person_type="REAL")
+        early_warnings = [w for w in result.warnings if "第三者視点" in w]
+        assert len(early_warnings) == 0
+
+    def test_no_check_for_age_6(self):
+        """6歳以上では幼児品質チェックを行わない"""
+        text = "あなたと同じ6歳のとき、彼は論文を執筆した。" + "テスト" * 30
+        result = self.validator.validate(text, age=6, person_type="REAL")
+        early_errors = [e for e in result.errors if "幼児エピソード品質違反" in e]
+        assert len(early_errors) == 0
+
+    def test_no_check_when_age_is_none(self):
+        """ageがNoneの場合は幼児品質チェックを行わない"""
+        text = "あなたと同じ3歳のとき、彼は論文を発表した。" + "テスト" * 30
+        result = self.validator.validate(text, age=None, person_type="REAL")
+        early_errors = [e for e in result.errors if "幼児エピソード品質違反" in e]
+        assert len(early_errors) == 0
+
+
+class TestCheckFictionalWorkTitleDirect:
+    """_check_fictional_work_title() メソッドの直接テスト"""
+
+    def setup_method(self):
+        self.validator = PostLLMValidator()
+
+    def test_matching_title_returns_no_error(self):
+        """正しい作品名がある場合はエラーなし"""
+        text = "あなたと同じ16歳のとき、悟空『ドラゴンボール』は修行した。"
+        result = self.validator._check_fictional_work_title(text, "ドラゴンボール")
+        assert result["error"] is None
+
+    def test_no_title_at_all(self):
+        """作品名が全くない場合"""
+        text = "あなたと同じ16歳のとき、悟空は修行した。"
+        result = self.validator._check_fictional_work_title(text, "ドラゴンボール")
+        assert result["error"] is not None
+        assert "冒頭にありません" in result["error"]
+
+    def test_different_title_present(self):
+        """異なる作品名が含まれている場合"""
+        text = "あなたと同じ16歳のとき、悟空『NARUTO』は修行した。"
+        result = self.validator._check_fictional_work_title(text, "ドラゴンボール")
+        assert result["error"] is not None
+        assert "一致しません" in result["error"]
+
+
+class TestCheckEarlyChildhoodQualityDirect:
+    """_check_early_childhood_quality() メソッドの直接テスト"""
+
+    def setup_method(self):
+        self.validator = PostLLMValidator()
+
+    def test_clean_text_returns_empty_errors(self):
+        """問題のないテキストはエラーなし"""
+        text = "伝記によると彼は3歳で初めて音楽に触れたとされている。"
+        result = self.validator._check_early_childhood_quality(text, 3)
+        assert len(result["errors"]) == 0
+
+    def test_forbidden_action_detected(self):
+        """禁止行動を含むテキストでエラー検出"""
+        text = "3歳の頃、彼は論文を執筆した。"
+        result = self.validator._check_early_childhood_quality(text, 3)
+        assert len(result["errors"]) > 0
+
+    def test_multiple_forbidden_patterns(self):
+        """複数の禁止パターンが検出される"""
+        text = "2歳で制作した作品を発表した。さらに情熱を秘めていた。"
+        result = self.validator._check_early_childhood_quality(text, 2)
+        assert len(result["errors"]) >= 2
+
+    def test_missing_recommended_pattern_warns(self):
+        """推奨パターンなしで警告"""
+        text = "彼は3歳で明るく元気だった。"
+        result = self.validator._check_early_childhood_quality(text, 3)
+        assert len(result["warnings"]) > 0
+
+    def test_has_recommended_pattern_no_warn(self):
+        """推奨パターンありで警告なし"""
+        text = "家族の証言によると彼は3歳で初めて声を上げた。"
+        result = self.validator._check_early_childhood_quality(text, 3)
+        assert len(result["warnings"]) == 0
+
+
 class TestMainFunction:
     """main関数テスト（カバレッジ向上用）"""
 


### PR DESCRIPTION
## Summary
- テストカバレッジを14.9%から89%に向上（目標30%を大幅超過）
- EPUP品質ゲート・バリデーション・モデル系モジュールのテストを追加・拡充
- CI用XMLカバレッジレポート出力を追加

### 追加・拡充したテスト

| モジュール | Before | After |
|-----------|--------|-------|
| `episode_name_validator.py` | 0% | **100%** |
| `age_distribution_checker.py` | 0% | **99%** |
| `group_contamination_validator.py` | 0% | **98%** |
| `post_llm_validator.py` | 17% | **98%** |
| `verified_source.py` | 20.5% | **99%** |
| `episode_source.py` | 23% | **98%** |
| `duplication_detector.py` | 8.8% | 拡充 |

### pyproject.toml 変更
- `--cov-report=xml` 追加（CI上でのカバレッジ可視化対応）

## Test plan
- [x] 全テストPASS確認
- [x] ruff format/check PASS確認
- [x] pre-commit hooks 全PASS確認
- [x] カバレッジ89%達成確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 複数のテストスイートを拡張し、エピソード検証、年齢分布チェック、重複検出など各機能の網羅的なテストカバレッジを追加しました。
  
* **Chores**
  * XML 形式のカバレッジレポート生成を有効化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->